### PR TITLE
fix: rewind file before S3 upload

### DIFF
--- a/app_admin.py
+++ b/app_admin.py
@@ -282,6 +282,7 @@ def upload_file_to_s3(s3_client, bucket_name, file_obj, s3_key):
     Returns (success: bool, url: str)
     """
     try:
+        file_obj.seek(0)  # Rebobina el archivo para iniciar la carga desde el inicio
         s3_client.upload_fileobj(file_obj, bucket_name, s3_key)
         url = f"https://{bucket_name}.s3.amazonaws.com/{s3_key}"
         return True, url


### PR DESCRIPTION
## Summary
- ensure file-like objects are rewound before uploading to S3

## Testing
- `python -m pytest`
- `python -m py_compile app_admin.py app_v.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4ba8a0ad48326b5749a36e7df68a5