### PR TITLE
Fix tab persistence after saving return confirmation

### DIFF
--- a/app_admin.py
+++ b/app_admin.py
@@ -1415,7 +1415,6 @@ with tab3:
         if ok_all:
             tab3_alert.success("✅ Confirmación guardada.")
             st.session_state["tab3_reload_nonce"] += 1
-            st.cache_data.clear()
         else:
             tab3_alert.error("❌ Ocurrió un problema al guardar.")
 


### PR DESCRIPTION
## Summary
- Prevent admin interface from switching tabs after saving a devolución confirmation by avoiding cache clearing

## Testing
- `python -m py_compile app_admin.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4c563cbe0832682c5afa3eb45b08f