### PR TITLE
fix: mantener pestaña activa en app admin

### DIFF
--- a/app_admin.py
+++ b/app_admin.py
@@ -317,9 +317,14 @@ else:
 
 # ---- TABS ADMIN ----
 tab_names = ["💳 Pendientes de Confirmar", "📥 Confirmados", "📦 Casos Especiales", "🗂️ Data Especiales"]
-tab_index = st.session_state.get("active_tab_admin_index", 0)
-# Nota: streamlit.tabs() no acepta índice activo programático, pero conservamos tab_index por si lo usas con query params.
-tab1, tab2, tab3, tab4 = st.tabs(tab_names)
+# Añadimos un key para que Streamlit recuerde la pestaña activa tras cada interacción
+tabs = st.tabs(tab_names, key="admin_tabs")
+tab1, tab2, tab3, tab4 = tabs
+
+# Guardamos el índice de la pestaña activa en session_state para usos futuros
+st.session_state["active_tab_admin_index"] = tab_names.index(
+    st.session_state.get("admin_tabs", tab_names[0])
+)
 
 
 # --- INTERFAZ PRINCIPAL ---


### PR DESCRIPTION
## Summary
- prevent admin tab from resetting to first tab by storing active tab in session state

## Testing
- `python -m py_compile app_admin.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4eb1911d48326a2a2ecf05ca78c43