### PR TITLE
Handle non-string values in warranty information

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -2383,8 +2383,8 @@ with tab6:
 
                         # ⭐⭐⭐ NUEVO: Mostrar datos de Garantía ⭐⭐⭐
                         if str(res.get("Tipo_Envio","")).strip() == "🛠 Garantía":
-                            num_serie = (res.get("Numero_Serie") or "").strip()
-                            fec_compra = (res.get("Fecha_Compra") or "").strip()
+                            num_serie = str(res.get("Numero_Serie") or "").strip()
+                            fec_compra = str(res.get("Fecha_Compra") or "").strip()
                             if num_serie or fec_compra:
                                 st.markdown("**🧷 Datos de compra y serie (Garantía):**")
                                 st.markdown(f"- **Número de serie / lote:** `{num_serie or 'N/A'}`")


### PR DESCRIPTION
## Summary
- Avoid AttributeError when Numero_Serie or Fecha_Compra are not strings in warranty section of tab 6

## Testing
- `python -m py_compile app_v.py app_admin.py`


------
https://chatgpt.com/codex/tasks/task_e_68abd66e4b3c8326896cf06d60bfb72a