### PR TITLE
Fix special cases tab showing empty rows

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -173,6 +173,18 @@ def cargar_casos_especiales():
     data = ws.get_all_records()
     df = pd.DataFrame(data)
 
+    # Eliminar filas completamente vacías (celdas en blanco o 'N/A')
+    if not df.empty:
+        df = df[
+            ~df.apply(
+                lambda fila: all(
+                    (str(v).strip() == "") or (str(v).strip().lower() in ("n/a", "na", "nan"))
+                    for v in fila.values
+                ),
+                axis=1,
+            )
+        ]
+
     columnas_necesarias = [
         "ID_Pedido","Cliente","Vendedor_Registro","Folio_Factura","Folio_Factura_Error",
         "Hora_Registro","Tipo_Envio","Estado","Estado_Caso","Turno",


### PR DESCRIPTION
## Summary
- skip empty entries when loading special cases

## Testing
- `python -m py_compile app_v.py app_admin.py`


------
https://chatgpt.com/codex/tasks/task_e_68b066df7fc08326bdb9ee775227be93