### PR TITLE
Display original shipping type in special case view

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -304,7 +304,8 @@ def render_caso_especial(row):
     st.markdown(
         f"**Estado:** {row.get('Estado','') or 'N/A'}  |  "
         f"**Estado del Caso:** {row.get('Estado_Caso','') or 'N/A'}  |  "
-        f"**Turno:** {row.get('Turno','') or 'N/A'}"
+        f"**Turno:** {row.get('Turno','') or 'N/A'}  |  "
+        f"**Tipo Envío Original:** {row.get('Tipo_Envio_Original','') or 'N/A'}"
     )
     st.markdown(f"**📌 Seguimiento:** {row.get('Seguimiento', 'N/A')}")
 


### PR DESCRIPTION
## Summary
- Show original shipping type alongside turn, state, and case state in `render_caso_especial`

## Testing
- `python -m py_compile app_v.py app_admin.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3466acf388326a66f331adc3d59fa