### PR TITLE
Remove index from special cases selector

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -1873,7 +1873,7 @@ with tab4:
             st.dataframe(df_casos[columnas_mostrar], use_container_width=True, hide_index=True)
 
             df_casos["display_label"] = df_casos.apply(
-                lambda r: f"{r.name} - {r['Estado']} - {r['Cliente']} ({r['Tipo_Envio']})", axis=1
+                lambda r: f"{r['Estado']} - {r['Cliente']} ({r['Tipo_Envio']})", axis=1
             )
             selected_case = st.selectbox(
                 "📂 Selecciona un caso para ver detalles",


### PR DESCRIPTION
## Summary
- remove index from Casos Especiales display labels so the selector only shows estado, cliente and tipo de envio

## Testing
- `python -m py_compile app_v.py`
- `python - <<'PY'
import pandas as pd

df_casos = pd.DataFrame({
    'Estado': ['Nuevo', 'En proceso'],
    'Cliente': ['Cliente A', 'Cliente B'],
    'Tipo_Envio': ['🔁 Devolución', '🛠 Garantía']
})

df_casos['display_label'] = df_casos.apply(lambda r: f"{r['Estado']} - {r['Cliente']} ({r['Tipo_Envio']})", axis=1)

print(df_casos['display_label'].tolist())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b35161fb5c83269d4e804ff21a1020