### PR TITLE
fix: avoid session state mutation after selectbox

### DIFF
--- a/app_admin.py
+++ b/app_admin.py
@@ -1605,7 +1605,6 @@ with tab3, suppress(StopException):
             tab3_alert.success("✅ Confirmación guardada.")
             st.session_state["tab3_reload_nonce"] += 1
             st.cache_data.clear()
-            st.session_state[seg_key] = seguimiento_sel
             st.query_params["tab"] = "2"
             st.rerun()
         else:


### PR DESCRIPTION
## Summary
- remove session state update after selectbox selection to prevent StreamlitAPIException on save

## Testing
- `python -m py_compile app_admin.py`
- `streamlit run app_admin.py --server.headless true --server.port 8501`


------
https://chatgpt.com/codex/tasks/task_e_68b35a6cbff08326a82e49f5bc171363