### PR TITLE
Preserve existing admin comments in text area

### DIFF
--- a/app_admin.py
+++ b/app_admin.py
@@ -1551,9 +1551,17 @@ with tab3, suppress(StopException):
             type=["pdf","jpg","jpeg","png"],
             key=f"doc_extra_{row.get('ID_Pedido','')}"
         )
+        comentario_existente = row.get(
+            "Comentarios_Admin_Devolucion" if is_dev else "Comentarios_Admin_Garantia",
+            ""
+        )
+        comment_key = f"comentario_admin_{row.get('ID_Pedido','')}"
+        if comment_key not in st.session_state:
+            st.session_state[comment_key] = comentario_existente
         comentario_admin = st.text_area(
             "📝 Comentario administrativo final",
-            key=f"comentario_admin_{row.get('ID_Pedido','')}"
+            key=comment_key,
+            value=st.session_state[comment_key]
         )
         submitted = st.form_submit_button("💾 Guardar Confirmación", use_container_width=True)
 


### PR DESCRIPTION
## Summary
- Preload final admin comment field with stored value
- Persist edits via Streamlit session state keyed by order ID

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app_admin.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4f698fdb88326b8942a033d8d7a92