### PR TITLE
Ensure active tab persists after rerun

### DIFF
--- a/app_admin.py
+++ b/app_admin.py
@@ -375,6 +375,8 @@ st.markdown(
 
 # --- INTERFAZ PRINCIPAL ---
 with tab1:
+    if st.query_params.get("tab", ["0"])[0] != "0":
+        st.query_params["tab"] = "0"
     st.session_state["current_tab"] = "0"
     st.header("💳 Comprobantes de Pago Pendientes de Confirmación")
     mostrar = True  # ✅ Se inicializa desde el inicio del tab
@@ -890,6 +892,8 @@ with tab1:
                             st.warning("Funcionalidad pendiente.")
 # --- TAB 2: PEDIDOS CONFIRMADOS ---
 with tab2:
+    if st.query_params.get("tab", ["0"])[0] != "1":
+        st.query_params["tab"] = "1"
     st.session_state["current_tab"] = "1"
     st.header("📥 Pedidos Confirmados")
 
@@ -1126,6 +1130,8 @@ with tab2:
         )
 # --- TAB 3: CONFIRMACIÓN DE CASOS (Devoluciones + Garantías, con tabla y selectbox) ---
 with tab3, suppress(StopException):
+    if st.query_params.get("tab", ["0"])[0] != "2":
+        st.query_params["tab"] = "2"
     st.session_state["current_tab"] = "2"
     st.header("📦 Confirmación de Casos (Devoluciones + Garantías)")
 
@@ -1670,6 +1676,8 @@ with tab3, suppress(StopException):
 
 # --- TAB 4: CASOS ESPECIALES (Descarga Devoluciones/Garantías) ---
 with tab4:
+    if st.query_params.get("tab", ["0"])[0] != "3":
+        st.query_params["tab"] = "3"
     st.session_state["current_tab"] = "3"
     st.header("📥 Casos Especiales (Devoluciones/Garantías)")
 


### PR DESCRIPTION
## Summary
- Persist tab selection across reruns by updating `st.query_params["tab"]` in each tab block

## Testing
- `python -m py_compile app_admin.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4f97c70d08326ba11e25c59a7e2b0