### PR TITLE
Fix rerun warning for Casos especiales reload button

### DIFF
--- a/app_admin.py
+++ b/app_admin.py
@@ -1209,12 +1209,12 @@ with tab3, suppress(StopException):
             st.query_params["tab"] = st.session_state.get("current_tab", "0")
             st.rerun()
 
-        st.button(
+        if st.button(
             "🔄 Recargar casos",
             type="secondary",
             key="tab3_reload_btn",
-            on_click=_reload_tab3,
-        )
+        ):
+            _reload_tab3()
 
     # Carga principal
     try:


### PR DESCRIPTION
## Summary
- prevent Streamlit warning by moving `st.rerun()` outside the callback for the **Recargar casos** button

## Testing
- `python -m py_compile app_admin.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4fc6c327c8326aba89f60b9a963c4