### PR TITLE
refactor: preserve active tab on refresh

### DIFF
--- a/app_admin.py
+++ b/app_admin.py
@@ -79,6 +79,12 @@ def safe_open_worksheet(sheet_id: str, worksheet_name: str, retries: int = 3):
 
 st.set_page_config(page_title="App Admin TD", layout="wide")
 
+
+def rerun_current_tab():
+    """Rerun Streamlit keeping the current tab in query params."""
+    st.query_params["tab"] = st.session_state.get("current_tab", "0")
+    st.experimental_rerun()
+
 def _get_ws_datos():
     """Devuelve la worksheet 'datos_pedidos' con reintentos (usa safe_open_worksheet)."""
     return safe_open_worksheet(GOOGLE_SHEET_ID, "datos_pedidos")
@@ -399,8 +405,7 @@ with tab1:
             cargar_pedidos_desde_google_sheet.clear()
             get_google_sheets_client.clear()
             st.toast("Pedidos recargados", icon="🔄")
-            st.query_params["tab"] = st.session_state.get("current_tab", "0")
-            st.rerun()
+            rerun_current_tab()
 
     if df_pedidos.empty:
         st.info("ℹ️ No hay pedidos cargados en este momento.")
@@ -535,8 +540,7 @@ with tab1:
                                 st.balloons()
                                 time.sleep(2)
                                 cargar_pedidos_desde_google_sheet.clear()
-                                st.query_params["tab"] = st.session_state.get("current_tab", "0")
-                                st.rerun()
+                                rerun_current_tab()
 
                             except Exception as e:
                                 st.error(f"❌ Error al guardar la confirmación: {e}")
@@ -681,8 +685,7 @@ with tab1:
                         st.balloons()
                         time.sleep(2)
                         cargar_pedidos_desde_google_sheet.clear()
-                        st.query_params["tab"] = st.session_state.get("current_tab", "0")
-                        st.rerun()
+                        rerun_current_tab()
 
                     except Exception as e:
                         st.error(f"❌ Error al guardar el comprobante: {e}")
@@ -894,8 +897,7 @@ with tab1:
                                 st.balloons()
                                 time.sleep(3)
                                 cargar_pedidos_desde_google_sheet.clear()
-                                st.query_params["tab"] = st.session_state.get("current_tab", "0")
-                                st.rerun()
+                                rerun_current_tab()
 
                             except Exception as e:
                                 st.error(f"❌ Error al confirmar comprobante: {e}")
@@ -1086,8 +1088,7 @@ with tab2:
                 st.session_state["tab2_reload_nonce"] += 1
                 cargar_confirmados_guardados_cached.clear()
                 st.toast("Datos recargados", icon="🔄")
-                st.query_params["tab"] = st.session_state.get("current_tab", "0")
-                st.rerun()
+                rerun_current_tab()
 
             except gspread.exceptions.APIError as e:
                 tab2_alert.error(f"❌ Error de Google API al actualizar/recargar: {e}")
@@ -1205,8 +1206,7 @@ with tab3, suppress(StopException):
             st.session_state["tab3_reload_nonce"] += 1
             get_raw_sheet_data_cached.clear()
             st.toast("Casos recargados", icon="🔄")
-            st.query_params["tab"] = st.session_state.get("current_tab", "0")
-            st.rerun()
+            rerun_current_tab()
 
         if st.button(
             "🔄 Recargar casos",
@@ -1482,8 +1482,7 @@ with tab3, suppress(StopException):
 
     def _keep_tab3():
         st.toast("Actualizando caso", icon="🔄")
-        st.query_params["tab"] = st.session_state.get("current_tab", "0")
-        st.rerun()
+        rerun_current_tab()
 
     selected = st.selectbox(
         "📋 Selecciona un caso",
@@ -1686,8 +1685,7 @@ with tab3, suppress(StopException):
             st.session_state["tab3_reload_nonce"] += 1
             get_raw_sheet_data_cached.clear()
             st.toast("Confirmación guardada", icon="✅")
-            st.query_params["tab"] = st.session_state.get("current_tab", "0")
-            st.rerun()
+            rerun_current_tab()
         else:
             tab3_alert.error("❌ Ocurrió un problema al guardar.")
 
@@ -1733,6 +1731,7 @@ with tab4:
                 st.session_state["tab4_reload_nonce"] += 1
                 cargar_casos_especiales_cached.clear()
                 st.toast("♻️ Casos recargados.", icon="♻️")
+                rerun_current_tab()
 
     # leer hoja
     try:


### PR DESCRIPTION
## Summary
- add `rerun_current_tab` helper to rerun Streamlit while keeping the selected tab
- replace duplicated tab-preserving rerun code with `rerun_current_tab`
- ensure Tab 4's "Recargar Casos" button reruns without leaving the tab

## Testing
- `python -m py_compile app_admin.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b502c23ca08326ac99a47de446958b