### PR TITLE
Replace deprecated Streamlit rerun call

### DIFF
--- a/app_admin.py
+++ b/app_admin.py
@@ -83,7 +83,7 @@ st.set_page_config(page_title="App Admin TD", layout="wide")
 def rerun_current_tab():
     """Rerun Streamlit keeping the current tab in query params."""
     st.query_params["tab"] = st.session_state.get("current_tab", "0")
-    st.experimental_rerun()
+    st.rerun()
 
 def _get_ws_datos():
     """Devuelve la worksheet 'datos_pedidos' con reintentos (usa safe_open_worksheet)."""


### PR DESCRIPTION
## Summary
- use `st.rerun()` instead of deprecated `st.experimental_rerun()`

## Testing
- `python -m py_compile app_admin.py`
- `python app_admin.py` *(fails: AttributeError: 'NoneType' object has no attribute 'open_by_key')*

------
https://chatgpt.com/codex/tasks/task_e_68b5045a674c83268be499c4df9cfc35