### PR TITLE
Respect query parameter tab selection in admin

### DIFF
--- a/app_admin.py
+++ b/app_admin.py
@@ -377,19 +377,9 @@ except Exception:
 # mantener en session_state la pestaña activa
 st.session_state.setdefault("current_tab", str(_default_tab))
 
-tabs = st.tabs(tab_names)
+# Renderizar las pestañas respetando el índice de la URL
+tabs = st.tabs(tab_names, key="admin_tabs", default_index=_default_tab)
 tab1, tab2, tab3, tab4 = tabs
-
-# forza la pestaña almacenada al recargar
-st.markdown(
-    f"""
-    <script>
-        const tabs = window.parent.document.querySelectorAll('div[data-baseweb="tab-list"] button');
-        if (tabs.length > {_default_tab}) {{ tabs[{_default_tab}].click(); }}
-    </script>
-    """,
-    unsafe_allow_html=True,
-)
 
 
 # --- INTERFAZ PRINCIPAL ---


### PR DESCRIPTION
## Summary
- use Streamlit's `default_index` and a unique key to honor admin tab selections from query parameters
- drop JavaScript hack for tab focus and rely on Streamlit's native handling

## Testing
- `python -m py_compile app_admin.py`
- `streamlit run app_admin.py --server.headless true --browser.gatherUsageStats false` *(server started)*


------
https://chatgpt.com/codex/tasks/task_e_68b50dd8af10832682c794acb7f13667