### PR TITLE
Centralize admin tab state control

### DIFF
--- a/app_admin.py
+++ b/app_admin.py
@@ -84,8 +84,16 @@ st.set_page_config(page_title="App Admin TD", layout="wide")
 
 def rerun_current_tab():
     """Rerun Streamlit keeping the current tab in query params."""
-    st.query_params["tab"] = st.session_state.get("current_tab", "0")
+    st.experimental_set_query_params(tab=st.session_state.get("current_tab", "0"))
     st.rerun()
+
+
+def set_active_tab(index: int) -> None:
+    """Centraliza el control de la pestaña activa y sincroniza los query params."""
+    idx = str(index)
+    if st.session_state.get("current_tab") != idx:
+        st.session_state["current_tab"] = idx
+        st.experimental_set_query_params(tab=idx)
 
 def _get_ws_datos():
     """Devuelve la worksheet 'datos_pedidos' con reintentos (usa safe_open_worksheet)."""
@@ -381,7 +389,7 @@ except Exception as e:
 pedidos_pagados_no_confirmados = st.session_state.get('pedidos_pagados_no_confirmados', pd.DataFrame())
 
 # ---- TABS ADMIN ----
-# Mantiene la pestaña activa usando los query params de Streamlit
+# Mantiene la pestaña activa usando session_state
 tab_names = [
     "💳 Pendientes de Confirmar",
     "📥 Confirmados",
@@ -389,20 +397,13 @@ tab_names = [
     "🗂️ Data Especiales",
 ]
 
-# índice de pestaña activo desde la URL (por defecto 0)
-_tab_param = st.query_params.get("tab", ["0"])[0]
-try:
-    _default_tab = int(_tab_param)
-except Exception:
-    _default_tab = 0
-
-# mantener en session_state la pestaña activa
+_default_tab = int(st.session_state.get("current_tab", "0"))
 st.session_state.setdefault("current_tab", str(_default_tab))
 
 tabs = st.tabs(tab_names)
 tab1, tab2, tab3, tab4 = tabs
 
-# forza la pestaña almacenada al recargar
+# fuerza la pestaña almacenada al recargar
 st.markdown(
     f"""
     <script>
@@ -416,9 +417,7 @@ st.markdown(
 
 # --- INTERFAZ PRINCIPAL ---
 with tab1:
-    if st.query_params.get("tab", ["0"])[0] != "0":
-        st.query_params["tab"] = "0"
-    st.session_state["current_tab"] = "0"
+    set_active_tab(0)
     st.header("💳 Comprobantes de Pago Pendientes de Confirmación")
     mostrar = True  # ✅ Se inicializa desde el inicio del tab
 
@@ -1006,9 +1005,7 @@ with tab1:
                             st.warning("Funcionalidad pendiente.")
 # --- TAB 2: PEDIDOS CONFIRMADOS ---
 with tab2:
-    if st.query_params.get("tab", ["0"])[0] != "1":
-        st.query_params["tab"] = "1"
-    st.session_state["current_tab"] = "1"
+    set_active_tab(1)
     st.header("📥 Pedidos Confirmados")
 
     # Imports usados en este bloque
@@ -1246,9 +1243,7 @@ with tab2:
         )
 # --- TAB 3: CONFIRMACIÓN DE CASOS (Devoluciones + Garantías, con tabla y selectbox) ---
 with tab3, suppress(StopException):
-    if st.query_params.get("tab", ["0"])[0] != "2":
-        st.query_params["tab"] = "2"
-    st.session_state["current_tab"] = "2"
+    set_active_tab(2)
     st.header("📦 Confirmación de Casos (Devoluciones + Garantías)")
 
     from datetime import datetime
@@ -1800,9 +1795,7 @@ with tab3, suppress(StopException):
 
 # --- TAB 4: CASOS ESPECIALES (Descarga Devoluciones/Garantías) ---
 with tab4:
-    if st.query_params.get("tab", ["0"])[0] != "3":
-        st.query_params["tab"] = "3"
-    st.session_state["current_tab"] = "3"
+    set_active_tab(3)
     st.header("📥 Casos Especiales (Devoluciones/Garantías)")
 
     from io import BytesIO


### PR DESCRIPTION
## Summary
- centralize active admin tab handling with `set_active_tab`
- use `st.session_state` for initial tab and sync URL only on changes
- rerun helper preserves tab index during refresh actions

## Testing
- `python -m py_compile app_admin.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9b2d69c088326a3d7738efbf98121