### PR TITLE
Replace deprecated Streamlit rerun call

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -1106,7 +1106,7 @@ with tab1:
                     st.session_state.pop(key, None)
                 st.query_params.clear()
                 st.query_params.update({"tab": "0"})
-                st.experimental_rerun()
+                st.rerun()
             else:
                 st.error("❌ No se pudo registrar el pedido después de varios intentos.")
 


### PR DESCRIPTION
## Summary
- replace deprecated `st.experimental_rerun()` with `st.rerun()` in the order registration flow

## Testing
- `python -m py_compile app_v.py`
- `python -m py_compile app_admin.py`


------
https://chatgpt.com/codex/tasks/task_e_68bbca15a5748326b14430f1077ded0f