### PR TITLE
Optimiza cache de pedidos combinados y botón de actualización

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -1107,7 +1107,7 @@ with tab1:
 
 
 
-@st.cache_data(ttl=30)
+@st.cache_data(ttl=300)
 def cargar_pedidos_combinados():
     """
     Carga y unifica pedidos de 'datos_pedidos' y 'casos_especiales'.
@@ -1268,6 +1268,8 @@ if "reset_inputs_tab2" in st.session_state:
 
 with tab2:
     st.header("✏️ Modificar Pedido Existente")
+    if st.button("🔄 Actualizar pedidos"):
+        cargar_pedidos_combinados.clear()
 
     message_placeholder_tab2 = st.empty()
 


### PR DESCRIPTION
## Summary
- Eleva la duración del cache de `cargar_pedidos_combinados` a 5 minutos.
- Agrega botón "🔄 Actualizar pedidos" para refrescar la data desde Google Sheets.

## Testing
- `python -m py_compile app_v.py`


------
https://chatgpt.com/codex/tasks/task_e_68c44f55c90c83269467c86393497a31