### PR TITLE
refactor: avoid full sheet fetch during order update

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -1597,8 +1597,7 @@ with tab2:
                             worksheet = sh.worksheet(hoja_objetivo)
 
                             headers = worksheet.row_values(1)
-                            all_data_actual = worksheet.get_all_records()
-                            df_actual = pd.DataFrame(all_data_actual)
+                            df_actual = df_pedidos[df_pedidos["Fuente"] == selected_source].reset_index(drop=True)
 
                             if df_actual.empty or 'ID_Pedido' not in df_actual.columns:
                                 message_placeholder_tab2.error(f"❌ No se encontró 'ID_Pedido' en la hoja {hoja_objetivo}.")


### PR DESCRIPTION
## Summary
- reuse in-memory `df_pedidos` when updating orders to compute row index
- avoid `worksheet.get_all_records()` to reduce Google Sheets API usage

## Testing
- `python -m py_compile app_v.py`


------
https://chatgpt.com/codex/tasks/task_e_68c799d5112c8326b62705bf92d1df34