### PR TITLE
Trigger rerun after confirming payments

### DIFF
--- a/app_admin.py
+++ b/app_admin.py
@@ -685,7 +685,7 @@ with tab1:
 
                                 st.success("✅ Confirmación de crédito guardada exitosamente.")
                                 st.balloons()
-                                time.sleep(2)
+                                rerun_current_tab()
 
                             except Exception as e:
                                 st.error(f"❌ Error al guardar la confirmación: {e}")
@@ -864,7 +864,7 @@ with tab1:
 
                         st.success("✅ Comprobante y datos de pago guardados exitosamente.")
                         st.balloons()
-                        time.sleep(2)
+                        rerun_current_tab()
 
                     except Exception as e:
                         st.error(f"❌ Error al guardar el comprobante: {e}")
@@ -1099,7 +1099,7 @@ with tab1:
                                 st.session_state.pedidos_pagados_no_confirmados = pedidos_pagados_no_confirmados
                                 st.success("🎉 Comprobante confirmado exitosamente.")
                                 st.balloons()
-                                time.sleep(3)
+                                rerun_current_tab()
 
                             except Exception as e:
                                 st.error(f"❌ Error al confirmar comprobante: {e}")


### PR DESCRIPTION
## Summary
- trigger a rerun after confirming crédito orders so the pending list updates immediately
- do the same after guardar/confirmar comprobantes regulares to refresh the state

## Testing
- python -m compileall app_admin.py

------
https://chatgpt.com/codex/tasks/task_e_68cb1a8523ec8326890e0c678266ff22