### PR TITLE
Expand payment details for unpaid orders

### DIFF
--- a/app_admin.py
+++ b/app_admin.py
@@ -714,7 +714,10 @@ with tab1:
                         key="comprobante_local_no_pagado"
                     )
 
-                    with st.expander("📝 Detalles del Pago"):
+                    with st.expander(
+                        "📝 Detalles del Pago",
+                        expanded=selected_pedido_data.get("Estado_Pago", "").strip() == "🔴 No Pagado",
+                    ):
                         fecha_pago = st.date_input("📅 Fecha del Pago", value=datetime.today().date(), key="fecha_pago_local")
                         forma_pago = st.selectbox("💳 Forma de Pago", [
                             "Transferencia", "Depósito en Efectivo", "Tarjeta de Débito", "Tarjeta de Crédito", "Cheque"


### PR DESCRIPTION
## Summary
- open the payment details expander by default when an order is marked as not paid

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cb81cf5d188326830eb35b4524e9e6