### PR TITLE
Fix credit confirmation updates

### DIFF
--- a/app_admin.py
+++ b/app_admin.py
@@ -643,6 +643,7 @@ with tab1:
 
                                 # Actualizaciones
                                 updates = []
+                                local_updates = {}
                                 if "Comprobante_Confirmado" in headers:
                                     updates.append({
                                         "range": rowcol_to_a1(
@@ -651,6 +652,7 @@ with tab1:
                                         ),
                                         "values": [[confirmacion_credito]],
                                     })
+                                    local_updates["Comprobante_Confirmado"] = confirmacion_credito
 
                                 if "Comentario" in headers:
                                     comentario_existente = selected_pedido_data.get("Comentario", "")
@@ -667,6 +669,7 @@ with tab1:
                                         ),
                                         "values": [[comentario_final]],
                                     })
+                                    local_updates["Comentario"] = comentario_final
 
                                 if updates:
                                     safe_batch_update(worksheet, updates)
@@ -676,10 +679,12 @@ with tab1:
                                 df_idx = df_pedidos[df_pedidos['ID_Pedido'] == selected_pedido_data["ID_Pedido"]].index
                                 if len(df_idx) > 0:
                                     df_idx = df_idx[0]
-                                    for col, val in updates.items():
+                                    for col, val in local_updates.items():
                                         if col in df_pedidos.columns:
                                             df_pedidos.at[df_idx, col] = val
-                                pedidos_pagados_no_confirmados = pedidos_pagados_no_confirmados[pedidos_pagados_no_confirmados['ID_Pedido'] != selected_pedido_data["ID_Pedido"]]
+                                pedidos_pagados_no_confirmados = pedidos_pagados_no_confirmados[
+                                    pedidos_pagados_no_confirmados['ID_Pedido'] != selected_pedido_data["ID_Pedido"]
+                                ].copy()
                                 st.session_state.df_pedidos = df_pedidos
                                 st.session_state.pedidos_pagados_no_confirmados = pedidos_pagados_no_confirmados
 


### PR DESCRIPTION
## Summary
- ensure credit confirmation updates track confirmed fields separately before updating the local dataframe
- refresh session state tables after removing the confirmed order so it disappears from the pending list

## Testing
- not run (streamlit app)


------
https://chatgpt.com/codex/tasks/task_e_68cb825f7db483268bcf01f6c6c9e4d0