### PR TITLE
Add manual refresh control for guides tab

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -2353,6 +2353,14 @@ with tab5:
         st.session_state["current_tab_index"] = 4
     st.header("📦 Pedidos con Guías Subidas desde Almacén y Casos Especiales")
 
+    if st.button("🔄 Actualizar guías"):
+        if allow_refresh("guias_last_refresh"):
+            cargar_datos_guias_unificadas.clear()
+            get_worksheet.clear()
+            if hasattr(get_worksheet_casos_especiales, "clear"):
+                get_worksheet_casos_especiales.clear()
+            st.rerun()
+
     try:
         df_guias = cargar_datos_guias_unificadas()
     except Exception as e:


### PR DESCRIPTION
## Summary
- add a manual refresh button to the guides tab that respects the existing cooldown guard
- clear cached data sources before triggering a rerun so the latest guides are fetched

## Testing
- python -m py_compile app_v.py

------
https://chatgpt.com/codex/tasks/task_e_68cf2dc84af08326b5a8779e393de14f