### PR TITLE
Handle cooldown when opening casos especiales worksheet

### DIFF
--- a/app_admin.py
+++ b/app_admin.py
@@ -1807,7 +1807,13 @@ with tab3, suppress(StopException):
     gsheet_row_idx = int(matches[0]) + 2
 
     # Worksheet para escritura con reintentos
-    worksheet_casos = safe_open_worksheet(GOOGLE_SHEET_ID, "casos_especiales")
+    try:
+        worksheet_casos = safe_open_worksheet(GOOGLE_SHEET_ID, "casos_especiales")
+    except gspread.exceptions.APIError:
+        tab3_alert.warning(
+            "⚠️ Google Sheets está aplicando un cooldown. Se trabajará con el snapshot hasta que pase el bloqueo."
+        )
+        st.stop()
 
     # ========= RENDER DEL CASO SELECCIONADO (detecta si es Devolución o Garantía) =========
     tipo_case = str(row.get("Tipo_Envio","")).strip()


### PR DESCRIPTION
## Summary
- protect the worksheet fetch in tab 3 by catching Google Sheets API cooldown errors
- notify the user that a cooldown is active and that the snapshot will be used until it clears
- stop the Streamlit flow to avoid interacting with an unavailable worksheet

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d35221c5fc8326ab333e615b712a11