### PR TITLE
Update foráneo return address handling

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -632,7 +632,6 @@ with tab1:
     g_fecha_compra = None
     direccion_guia_retorno = ""
     direccion_envio_destino = ""
-    solicita_guia_foraneo = False
 
     # -------------------------------
     # --- FORMULARIO PRINCIPAL ---
@@ -682,16 +681,10 @@ with tab1:
         comentario = st.text_area("💬 Comentario / Descripción Detallada")
 
         if tipo_envio == "🚚 Pedido Foráneo":
-            solicita_guia_foraneo = st.checkbox("🧾 Solicitud de guía", key="solicita_guia_foraneo")
-            if solicita_guia_foraneo:
-                direccion_guia_retorno = st.text_area(
-                    "📬 Dirección para guía de retorno",
-                    key="direccion_guia_retorno_foraneo",
-                )
-            else:
-                if "direccion_guia_retorno_foraneo" in st.session_state:
-                    st.session_state["direccion_guia_retorno_foraneo"] = ""
-                direccion_guia_retorno = ""
+            direccion_guia_retorno = st.text_area(
+                "📬 Dirección para guía de retorno",
+                key="direccion_guia_retorno_foraneo",
+            )
 
         # --- Campos adicionales para Devolución ---
         if tipo_envio == "🔁 Devolución":
@@ -1346,7 +1339,7 @@ with tab1:
                 elif header == "Direccion_Guia_Retorno":
                     if tipo_envio in ["🔁 Devolución", "🛠 Garantía"]:
                         values.append(direccion_guia_retorno)
-                    elif tipo_envio == "🚚 Pedido Foráneo" and solicita_guia_foraneo:
+                    elif tipo_envio == "🚚 Pedido Foráneo" and direccion_guia_retorno.strip():
                         values.append(direccion_guia_retorno)
                     else:
                         values.append("")


### PR DESCRIPTION
## Summary
- remove the foráneo return guide checkbox and always render the return address field
- record the return guide address for foráneo orders whenever the textarea contains a value

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8790ed7bc83268655c9bf0da5f4d4