### PR TITLE
Improve comprobante URL extraction

### DIFF
--- a/app_admin.py
+++ b/app_admin.py
@@ -379,7 +379,7 @@ def build_adjuntos_map_from_pedidos(df: pd.DataFrame) -> dict[str, object]:
 def extract_comprobante_urls_from_adjuntos(value) -> list[str]:
     """Extrae todas las URLs disponibles desde el campo Adjuntos."""
 
-    url_pattern = re.compile(r"https?://[^\s,;]+", re.IGNORECASE)
+    url_pattern = re.compile(r"https?://[^\s,;\"'<>)}\]]+", re.IGNORECASE)
     results: list[str] = []
     seen: set[str] = set()
 
@@ -387,6 +387,9 @@ def extract_comprobante_urls_from_adjuntos(value) -> list[str]:
         if not url:
             return
         url_text = str(url).strip()
+        if not url_text:
+            return
+        url_text = url_text.rstrip("\"'>)}]")
         if not url_text:
             return
         lowered = url_text.lower()


### PR DESCRIPTION
## Summary
- extend comprobante URL matching to stop at quotes and closing delimiters
- trim lingering closing characters before deduplication so downstream consumers receive clean links

## Testing
- python - <<'PY'
[custom script exercising extract_comprobante_urls_from_adjuntos and build_and_upload_comprobante_index_from_urls]
PY

------
https://chatgpt.com/codex/tasks/task_e_68da3dd535e08326bf003a5f8239aaa0