### PR TITLE
Add acknowledgment flow for tab 2 success message

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -2001,11 +2001,25 @@ with tab2:
         'last_updated_order_id' in st.session_state
     ):
         pedido_id = st.session_state.last_updated_order_id
-        message_placeholder_tab2.success(f"🎉 ¡Cambios guardados con éxito para el pedido **{pedido_id}**!")
-        st.balloons()
-        st.toast(f"✅ Pedido {pedido_id} actualizado", icon="📦")
-        del st.session_state.show_success_message
-        del st.session_state.last_updated_order_id
+        with message_placeholder_tab2.container():
+            st.success(
+                f"🎉 ¡Cambios guardados con éxito para el pedido **{pedido_id}**!"
+            )
+            if st.button("Aceptar", key="ack_mod_success"):
+                for state_key in (
+                    "show_success_message",
+                    "last_updated_order_id",
+                    "_mod_tab2_success_feedback_sent",
+                ):
+                    st.session_state.pop(state_key, None)
+                message_placeholder_tab2.empty()
+        if (
+            st.session_state.get("show_success_message")
+            and not st.session_state.get("_mod_tab2_success_feedback_sent")
+        ):
+            st.balloons()
+            st.toast(f"✅ Pedido {pedido_id} actualizado", icon="📦")
+            st.session_state["_mod_tab2_success_feedback_sent"] = True
 
 
 # --- TAB 3: PENDING PROOF OF PAYMENT ---


### PR DESCRIPTION
## Summary
- wrap the tab 2 success feedback in a container to group the message with new controls
- add an "Aceptar" button that clears success-related session state and placeholder when acknowledged
- ensure toast and balloons trigger only once per success event

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd733169dc83268c4f7030115724aa