### PR TITLE
Adjust modification type selectbox order

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -1753,8 +1753,8 @@ with tab2:
                 # ----------------- Tipo de modificación -----------------
                 tipo_modificacion_seleccionada = st.selectbox(
                     "📌 ¿Qué tipo de modificación estás registrando?",
-                    ["Refacturación", "Nueva Ruta", "Otro"],
-                    index=0,
+                    ["Otro", "Nueva Ruta", "Refacturación"],
+                    index=2,
                     key="tipo_modificacion_mod"
                 )
 


### PR DESCRIPTION
## Summary
- reorder the modification type selectbox options and keep Refacturación selected by default

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd7779b5d0832698d17182164cbd68