### PR TITLE
Filtrar solicitudes de guía en pendientes

### DIFF
--- a/app_admin.py
+++ b/app_admin.py
@@ -780,7 +780,11 @@ if "df_pedidos" not in st.session_state or "headers" not in st.session_state:
     st.session_state.df_pedidos = df_pedidos
     st.session_state.headers = headers
     if 'Comprobante_Confirmado' in df_pedidos.columns:
-        st.session_state.pedidos_pagados_no_confirmados = df_pedidos[df_pedidos['Comprobante_Confirmado'] != 'Sí'].copy()
+        pedidos_filtrados = df_pedidos[df_pedidos['Comprobante_Confirmado'] != 'Sí'].copy()
+        if 'Tipo_Envio' in pedidos_filtrados.columns:
+            tipo_envio_normalizado = pedidos_filtrados['Tipo_Envio'].fillna('').astype(str).str.strip()
+            pedidos_filtrados = pedidos_filtrados[tipo_envio_normalizado != 'Solicitudes de Guía'].copy()
+        st.session_state.pedidos_pagados_no_confirmados = pedidos_filtrados
 
 df_pedidos = st.session_state.df_pedidos
 headers = st.session_state.headers
@@ -1400,9 +1404,15 @@ with tab1:
             st.session_state.df_pedidos = df_pedidos
             st.session_state.headers = headers
             if 'Comprobante_Confirmado' in df_pedidos.columns:
-                st.session_state.pedidos_pagados_no_confirmados = df_pedidos[
+                pedidos_filtrados = df_pedidos[
                     df_pedidos['Comprobante_Confirmado'] != 'Sí'
                 ].copy()
+                if 'Tipo_Envio' in pedidos_filtrados.columns:
+                    tipo_envio_normalizado = pedidos_filtrados['Tipo_Envio'].fillna('').astype(str).str.strip()
+                    pedidos_filtrados = pedidos_filtrados[
+                        tipo_envio_normalizado != 'Solicitudes de Guía'
+                    ].copy()
+                st.session_state.pedidos_pagados_no_confirmados = pedidos_filtrados
             st.toast("Pedidos recargados", icon="🔄")
 
     if df_pedidos.empty:


### PR DESCRIPTION
## Summary
- excluye los pedidos marcados como "Solicitudes de Guía" al preparar los pagos no confirmados
- aplica el mismo filtro al recargar los pedidos para evitar que el estado acumule esos registros

## Testing
- streamlit run app_admin.py --server.port=8501 --server.headless=true *(falla por falta de credenciales de Google Sheets)*

------
https://chatgpt.com/codex/tasks/task_e_68deb14dd3008326a1c8f3fd6bf91b75