### PR TITLE
Show motivos in confirmados table

### DIFF
--- a/app_admin.py
+++ b/app_admin.py
@@ -67,6 +67,8 @@ COLUMNAS_OBJETIVO_CONFIRMADOS = [
     "Link_Adjuntos_Modificacion",
     "Link_Refacturacion",
     "Link_Adjuntos_Guia",
+    "Motivo_NotaVenta",
+    MOTIVO_RECHAZO_CANCELACION_COL,
 ]
 
 


### PR DESCRIPTION
## Summary
- add Motivo_NotaVenta and Motivo_Rechazo/Cancelacion to the confirmados column set so they remain visible in the admin view

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4a9cce57c832699a924e24841a25a