### PR TITLE
Ocultar campo de folio cuando se registra nota de venta

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -690,10 +690,11 @@ with tab1:
                 key="motivo_nota_venta_input",
                 help="Describe el motivo de la nota de venta, si se registró una.",
             )
-
-        # Folio normal (renombrado a 'Folio Nuevo' en devoluciones)
-        folio_label = "📄 Folio Nuevo" if tipo_envio == "🔁 Devolución" else "📄 Folio de Factura"
-        folio_factura_input_value = st.text_input(folio_label, key="folio_factura_input")
+            st.session_state.pop("folio_factura_input", None)
+        else:
+            # Folio normal (renombrado a 'Folio Nuevo' en devoluciones)
+            folio_label = "📄 Folio Nuevo" if tipo_envio == "🔁 Devolución" else "📄 Folio de Factura"
+            folio_factura_input_value = st.text_input(folio_label, key="folio_factura_input")
 
         # Campos de pedido normal (no Casos Especiales)
         if tipo_envio not in ["🔁 Devolución", "🛠 Garantía"]:


### PR DESCRIPTION
## Summary
- ocultar el campo de folio de factura cuando se habilita la opción de registrar nota de venta
- limpiar el valor previo del folio al ocultar el campo para evitar que se conserve un dato obsoleto

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68e539e6bc008326945ac8c3e92cc83a