### PR TITLE
Reemplazar columna en Reporte Diario: usar Forma_Pago_Comprobante

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -4891,7 +4891,7 @@ if tab_ventas_reportes is not None:
                 "Cliente",
                 "Folio_Factura",
                 "Monto_Comprobante",
-                "Banco_Destino_Pago",
+                "Forma_Pago_Comprobante",
                 "Comentario",
             ]
             st.caption("Solo se muestran pedidos marcados con forma de pago 'Depósito en Efectivo'.")


### PR DESCRIPTION
### Motivation
- Ajustar la vista y exportación del **📅 Reporte Diario** para mostrar la forma de pago del comprobante en lugar del banco destino, según el requerimiento de la sección Ventas y Reportes.

### Description
- En `app_v.py` se reemplazó `"Banco_Destino_Pago"` por `"Forma_Pago_Comprobante"` dentro de la lista `columnas_reporte_diario`, afectando la tabla mostrada y la exportación Excel del reporte diario.

### Testing
- Se compiló el archivo para verificar sintaxis con `python -m py_compile app_v.py`, y la compilación fue exitosa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d91e4892708326b2089f5f8e39febb)