### PR TITLE
Ajusta `tipo_envio_excel` para '🚚 Foráneo CDMX' en exportación a Excel

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -2882,6 +2882,7 @@ with tab1:
     tipo_envio_excel = tipo_envio_ui
     if tipo_envio_ui == "🚚 Foráneo CDMX":
         tipo_envio = "🚚 Pedido Foráneo"
+        tipo_envio_excel = "🚚 Pedido Foráneo"
     elif tipo_envio_ui == "📍 Local CDMX":
         tipo_envio = "📍 Pedido Local"
 


### PR DESCRIPTION
### Motivation
- Al exportar pedidos a Excel se debe escribir el valor `🚚 Pedido Foráneo` aunque en la UI se muestre `🚚 Foráneo CDMX`, para mantener consistencia en los archivos generados.

### Description
- Se actualizó `app_v.py` para asignar `tipo_envio_excel = "🚚 Pedido Foráneo"` cuando `tipo_envio_ui == "🚚 Foráneo CDMX"`, sin modificar la etiqueta visible en la interfaz.

### Testing
- Se ejecutó `python -m py_compile app_v.py` y la compilación fue exitosa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d92f34e7a08326b996cc934df1e292)