### PR TITLE
Add 'Pedidos CDMX' option and normalize Tab1 shipping view/mappings

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -2821,6 +2821,7 @@ with tab1:
         st.session_state["current_tab_index"] = TAB_INDEX_TAB1
     st.header("📝 Nuevo Pedido")
     id_vendedor_tab1 = normalize_vendedor_id(st.session_state.get("id_vendedor", ""))
+    tab1_allow_pedidos_cdmx_option = id_vendedor_tab1 not in LOCAL_TURNO_CDMX_IDS
     tab1_is_dual_view_user = id_vendedor_tab1 in TAB1_DUAL_VIEW_IDS
     tab1_view_mode_key = "tab1_shipping_view_mode"
     if tab1_is_dual_view_user:
@@ -2840,7 +2841,7 @@ with tab1:
                 current_view_mode = "cdmx"
     else:
         st.session_state.pop(tab1_view_mode_key, None)
-        current_view_mode = "cdmx" if id_vendedor_tab1 in LOCAL_TURNO_CDMX_IDS else "mty"
+        current_view_mode = "mty"
 
     tab1_special_shipping = current_view_mode == "cdmx"
     if tab1_special_shipping:
@@ -2854,20 +2855,31 @@ with tab1:
         ]
     else:
         tipo_envio_options = [
-            "🚚 Pedido Foráneo",
-            "📍 Pedido Local",
+            "🚚 Foráneo",
+            "📍 Local",
             "🔁 Devolución",
             "🛠 Garantía",
             "📋 Solicitudes de Guía",
             "🎓 Cursos y Eventos",
         ]
+    if tab1_allow_pedidos_cdmx_option:
+        tipo_envio_options.insert(1, "🏙️ Pedidos CDMX")
 
     current_tipo_envio = st.session_state.get("tipo_envio_selector_global", tipo_envio_options[0])
     if tab1_special_shipping:
-        if current_tipo_envio == "🚚 Pedido Foráneo":
+        if current_tipo_envio in {"🚚 Pedido Foráneo", "🚚 Foráneo"}:
             current_tipo_envio = "🚚 Foráneo CDMX"
-        elif current_tipo_envio in {"📍 Pedido Local", "🏙️ Pedido CDMX"}:
+        elif current_tipo_envio in {"📍 Pedido Local", "📍 Local"}:
             current_tipo_envio = "📍 Local CDMX"
+        elif current_tipo_envio in {"🏙️ Pedido CDMX", "🏙️ Pedidos CDMX"} and tab1_allow_pedidos_cdmx_option:
+            current_tipo_envio = "🏙️ Pedidos CDMX"
+    else:
+        if current_tipo_envio in {"🚚 Pedido Foráneo", "🚚 Foráneo CDMX"}:
+            current_tipo_envio = "🚚 Foráneo"
+        elif current_tipo_envio in {"📍 Pedido Local", "📍 Local CDMX"}:
+            current_tipo_envio = "📍 Local"
+        elif current_tipo_envio in {"🏙️ Pedido CDMX", "🏙️ Pedidos CDMX"} and tab1_allow_pedidos_cdmx_option:
+            current_tipo_envio = "🏙️ Pedidos CDMX"
     if current_tipo_envio not in tipo_envio_options:
         current_tipo_envio = tipo_envio_options[0]
         st.session_state["tipo_envio_selector_global"] = current_tipo_envio
@@ -2880,11 +2892,12 @@ with tab1:
     )
     tipo_envio = tipo_envio_ui
     tipo_envio_excel = tipo_envio_ui
-    if tipo_envio_ui == "🚚 Foráneo CDMX":
+    if tipo_envio_ui in {"🚚 Foráneo CDMX", "🚚 Foráneo", "🏙️ Pedidos CDMX"}:
         tipo_envio = "🚚 Pedido Foráneo"
-        tipo_envio_excel = "🚚 Pedido Foráneo"
-    elif tipo_envio_ui == "📍 Local CDMX":
+        tipo_envio_excel = "🏙️ Pedidos CDMX" if tipo_envio_ui == "🏙️ Pedidos CDMX" else "🚚 Pedido Foráneo"
+    elif tipo_envio_ui in {"📍 Local CDMX", "📍 Local"}:
         tipo_envio = "📍 Pedido Local"
+        tipo_envio_excel = "📍 Pedido Local"
 
     tipo_envio_original = ""
     if tipo_envio == "🔁 Devolución":
@@ -2913,7 +2926,7 @@ with tab1:
             st.markdown("---")
             st.subheader("⏰ Detalle de Pedido Local")
             local_shift_options = get_local_shift_options(
-                st.session_state.get("id_vendedor", ""),
+                st.session_state.get("id_vendedor", "") if tab1_special_shipping else None,
                 force_cdmx_view=tab1_special_shipping,
             )
             current_subtipo_local = st.session_state.get("subtipo_local_selector", local_shift_options[0])

--- a/app_v.py
+++ b/app_v.py
@@ -250,6 +250,14 @@ def resolve_local_delivery_slot(turno_local: str, hora_entrega_manual: str = "")
     return get_local_delivery_slot(turno_local)
 
 
+def get_subtipo_local_excel_value(subtipo_local: str) -> str:
+    """Normalize local shift label for Excel persistence."""
+    turno_normalizado = str(subtipo_local or "").strip()
+    if turno_normalizado == "🏙️ Local Mty":
+        return "🌤️ Local Día"
+    return turno_normalizado
+
+
 LOCAL_TURNO_CDMX_IDS = {"RUBEN67", "JUAN24", "FRANKO95"}
 TAB1_DUAL_VIEW_IDS = {"ALEJANDRO38", "CECILIA94"}
 
@@ -4436,7 +4444,7 @@ with tab1:
                 elif header == "Estatus_OrigenF":
                     values.append(estatus_origen_factura if tipo_envio == "🔁 Devolución" else "")
                 elif header == "Turno":
-                    values.append(subtipo_local)
+                    values.append(get_subtipo_local_excel_value(subtipo_local))
                 elif header == "Fecha_Entrega":
                     if tipo_envio in ["🔁 Devolución", "🛠 Garantía"]:
                         values.append("")


### PR DESCRIPTION
### Motivation
- Unify and extend Tab 1 shipping options so CDMX-specific selections behave consistently across dual/single view users and allow an explicit "Pedidos CDMX" option for eligible vendors.
- Ensure previously saved selector values map correctly after label changes to avoid leaving users with an invalid `tipo_envio_selector_global` state.

### Description
- Introduced `tab1_allow_pedidos_cdmx_option` (based on `id_vendedor_tab1` vs `LOCAL_TURNO_CDMX_IDS`) to control insertion of the "🏙️ Pedidos CDMX" option into `tipo_envio_options` and to gate normalization logic.
- Changed default `current_view_mode` for non-dual-view users to always be `"mty"` and preserved the dual-view toggle behavior for `TAB1_DUAL_VIEW_IDS` users.
- Normalized `tipo_envio_options` labels and added mapping branches so legacy values (e.g. `"🚚 Pedido Foráneo"`, `"📍 Pedido Local"`, `"🏙️ Pedido CDMX"`) are translated to the new options and back appropriately depending on `tab1_special_shipping` and `tab1_allow_pedidos_cdmx_option`.
- Adjusted `tipo_envio` / `tipo_envio_excel` assignment logic to handle the new `🏙️ Pedidos CDMX` selection and to keep Excel-export labels consistent.
- Changed call to `get_local_shift_options` to pass `st.session_state.get("id_vendedor", "")` only when `tab1_special_shipping` is true, otherwise pass `None` to avoid vendor-specific CDMX logic when not in CDMX view.

### Testing
- Ran the Python test suite with `pytest -q` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d941328bd483269a0011a3934539f1)