### PR TITLE
Normalize local shift Excel value and adapt Tab1 shipping view/options for MTY/CDMX vendors

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -250,6 +250,14 @@ def resolve_local_delivery_slot(turno_local: str, hora_entrega_manual: str = "")
     return get_local_delivery_slot(turno_local)
 
 
+def get_subtipo_local_excel_value(subtipo_local: str) -> str:
+    """Normalize local shift label for Excel persistence."""
+    turno_normalizado = str(subtipo_local or "").strip()
+    if turno_normalizado == "🏙️ Local Mty":
+        return "🌤️ Local Día"
+    return turno_normalizado
+
+
 LOCAL_TURNO_CDMX_IDS = {"RUBEN67", "JUAN24", "FRANKO95"}
 TAB1_DUAL_VIEW_IDS = {"ALEJANDRO38", "CECILIA94"}
 
@@ -2821,7 +2829,11 @@ with tab1:
         st.session_state["current_tab_index"] = TAB_INDEX_TAB1
     st.header("📝 Nuevo Pedido")
     id_vendedor_tab1 = normalize_vendedor_id(st.session_state.get("id_vendedor", ""))
+    tab1_allow_pedidos_cdmx_option = id_vendedor_tab1 not in LOCAL_TURNO_CDMX_IDS
     tab1_is_dual_view_user = id_vendedor_tab1 in TAB1_DUAL_VIEW_IDS
+    tab1_use_short_mty_labels = (
+        id_vendedor_tab1 in LOCAL_TURNO_CDMX_IDS or tab1_is_dual_view_user
+    )
     tab1_view_mode_key = "tab1_shipping_view_mode"
     if tab1_is_dual_view_user:
         current_view_mode = st.session_state.get(tab1_view_mode_key, "mty")
@@ -2840,7 +2852,7 @@ with tab1:
                 current_view_mode = "cdmx"
     else:
         st.session_state.pop(tab1_view_mode_key, None)
-        current_view_mode = "cdmx" if id_vendedor_tab1 in LOCAL_TURNO_CDMX_IDS else "mty"
+        current_view_mode = "mty"
 
     tab1_special_shipping = current_view_mode == "cdmx"
     if tab1_special_shipping:
@@ -2853,21 +2865,49 @@ with tab1:
             "🎓 Cursos y Eventos",
         ]
     else:
-        tipo_envio_options = [
-            "🚚 Pedido Foráneo",
-            "📍 Pedido Local",
-            "🔁 Devolución",
-            "🛠 Garantía",
-            "📋 Solicitudes de Guía",
-            "🎓 Cursos y Eventos",
-        ]
+        if tab1_use_short_mty_labels:
+            tipo_envio_options = [
+                "🚚 Foráneo",
+                "📍 Local",
+                "🔁 Devolución",
+                "🛠 Garantía",
+                "📋 Solicitudes de Guía",
+                "🎓 Cursos y Eventos",
+            ]
+        else:
+            tipo_envio_options = [
+                "🚚 Pedido Foráneo",
+                "📍 Pedido Local",
+                "🔁 Devolución",
+                "🛠 Garantía",
+                "📋 Solicitudes de Guía",
+                "🎓 Cursos y Eventos",
+            ]
+    if tab1_allow_pedidos_cdmx_option:
+        garantia_idx = tipo_envio_options.index("🛠 Garantía") if "🛠 Garantía" in tipo_envio_options else -1
+        tipo_envio_options.insert(garantia_idx + 1, "🏙️ Pedidos CDMX")
 
     current_tipo_envio = st.session_state.get("tipo_envio_selector_global", tipo_envio_options[0])
     if tab1_special_shipping:
-        if current_tipo_envio == "🚚 Pedido Foráneo":
+        if current_tipo_envio in {"🚚 Pedido Foráneo", "🚚 Foráneo"}:
             current_tipo_envio = "🚚 Foráneo CDMX"
-        elif current_tipo_envio in {"📍 Pedido Local", "🏙️ Pedido CDMX"}:
+        elif current_tipo_envio in {"📍 Pedido Local", "📍 Local"}:
             current_tipo_envio = "📍 Local CDMX"
+        elif current_tipo_envio in {"🏙️ Pedido CDMX", "🏙️ Pedidos CDMX"} and tab1_allow_pedidos_cdmx_option:
+            current_tipo_envio = "🏙️ Pedidos CDMX"
+    else:
+        if tab1_use_short_mty_labels:
+            if current_tipo_envio in {"🚚 Pedido Foráneo", "🚚 Foráneo CDMX"}:
+                current_tipo_envio = "🚚 Foráneo"
+            elif current_tipo_envio in {"📍 Pedido Local", "📍 Local CDMX"}:
+                current_tipo_envio = "📍 Local"
+        else:
+            if current_tipo_envio in {"🚚 Foráneo", "🚚 Foráneo CDMX"}:
+                current_tipo_envio = "🚚 Pedido Foráneo"
+            elif current_tipo_envio in {"📍 Local", "📍 Local CDMX"}:
+                current_tipo_envio = "📍 Pedido Local"
+        if current_tipo_envio in {"🏙️ Pedido CDMX", "🏙️ Pedidos CDMX"} and tab1_allow_pedidos_cdmx_option:
+            current_tipo_envio = "🏙️ Pedidos CDMX"
     if current_tipo_envio not in tipo_envio_options:
         current_tipo_envio = tipo_envio_options[0]
         st.session_state["tipo_envio_selector_global"] = current_tipo_envio
@@ -2880,11 +2920,12 @@ with tab1:
     )
     tipo_envio = tipo_envio_ui
     tipo_envio_excel = tipo_envio_ui
-    if tipo_envio_ui == "🚚 Foráneo CDMX":
+    if tipo_envio_ui in {"🚚 Foráneo CDMX", "🚚 Foráneo", "🏙️ Pedidos CDMX"}:
         tipo_envio = "🚚 Pedido Foráneo"
-        tipo_envio_excel = "🚚 Pedido Foráneo"
-    elif tipo_envio_ui == "📍 Local CDMX":
+        tipo_envio_excel = "🏙️ Pedidos CDMX" if tipo_envio_ui == "🏙️ Pedidos CDMX" else "🚚 Pedido Foráneo"
+    elif tipo_envio_ui in {"📍 Local CDMX", "📍 Local"}:
         tipo_envio = "📍 Pedido Local"
+        tipo_envio_excel = "📍 Pedido Local"
 
     tipo_envio_original = ""
     if tipo_envio == "🔁 Devolución":
@@ -2913,7 +2954,11 @@ with tab1:
             st.markdown("---")
             st.subheader("⏰ Detalle de Pedido Local")
             local_shift_options = get_local_shift_options(
-                st.session_state.get("id_vendedor", ""),
+                (
+                    st.session_state.get("id_vendedor", "")
+                    if (tab1_special_shipping or id_vendedor_tab1 in LOCAL_TURNO_CDMX_IDS)
+                    else None
+                ),
                 force_cdmx_view=tab1_special_shipping,
             )
             current_subtipo_local = st.session_state.get("subtipo_local_selector", local_shift_options[0])
@@ -4423,7 +4468,7 @@ with tab1:
                 elif header == "Estatus_OrigenF":
                     values.append(estatus_origen_factura if tipo_envio == "🔁 Devolución" else "")
                 elif header == "Turno":
-                    values.append(subtipo_local)
+                    values.append(get_subtipo_local_excel_value(subtipo_local))
                 elif header == "Fecha_Entrega":
                     if tipo_envio in ["🔁 Devolución", "🛠 Garantía"]:
                         values.append("")


### PR DESCRIPTION
### Motivation
- Ensure local shift labels are normalized for Excel export and make the Tab1 shipping UI/options adapt to vendor-specific MTY/CDMX views to reduce confusion and keep CSVs consistent.

### Description
- Add `get_subtipo_local_excel_value` to map `"🏙️ Local Mty"` to `"🌤️ Local Día"` for Excel persistence and return the raw value otherwise.
- Introduce `tab1_allow_pedidos_cdmx_option` and `tab1_use_short_mty_labels` to control whether the short MTY labels and the `"🏙️ Pedidos CDMX"` option are shown for the current vendor.
- Change Tab1 view defaulting so non-dual users default to `"mty"`, vary `tipo_envio_options` between short and long MTY labels, insert `"🏙️ Pedidos CDMX"` when allowed, and normalize `current_tipo_envio`/`tipo_envio`/`tipo_envio_excel` across the new label variants.
- Pass `id_vendedor` into `get_local_shift_options` only when `tab1_special_shipping` or the vendor is in `LOCAL_TURNO_CDMX_IDS`, and use `get_subtipo_local_excel_value` when writing the `Turno` column to the Excel row.

### Testing
- Ran the project's automated test suite with `pytest -q` and the tests relevant to Tab1 logic and CSV/export generation, and they passed.
- Executed existing UI-related smoke tests for Tab1 shipping options and Excel export paths, and they completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d941328bd483269a0011a3934539f1)