### PR TITLE
Make local delivery time editable with optional suggestions (Tab 1)

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -3278,7 +3278,7 @@ with tab1:
                     st.session_state["local_route_hora_entrega_selector_prev"] = hora_entrega_selector
 
                 local_route_hora_entrega = st.text_input(
-                    "🕒 HORA DE ENTREGA",
+                    "🕒 Hora de Entrega",
                     key="local_route_hora_entrega_manual",
                     placeholder="Ej. 11:30 AM a 4:00 PM",
                     help="Puedes elegir una sugerencia y luego borrar, editar o escribir cualquier horario.",

--- a/app_v.py
+++ b/app_v.py
@@ -108,6 +108,7 @@ TAB1_FORM_STATE_KEYS_TO_CLEAR: set[str] = {
     "local_route_referencias",
     "local_route_hora_entrega_manual",
     "local_route_hora_entrega_selector",
+    "local_route_hora_entrega_selector_prev",
     "local_route_hora_entrega_custom",
     "local_route_confirmed_payload",
     "local_route_confirmed_at",
@@ -139,11 +140,6 @@ LOCAL_ROUTE_GENERATED_FILE_KEY = "local_route_generated_file"
 LOCAL_ROUTE_GENERATED_FILENAME_KEY = "local_route_generated_filename"
 LOCAL_ROUTE_GENERATED_AT_KEY = "local_route_generated_at"
 LOCAL_ROUTE_POST_CONFIRM_NOTICE_KEY = "local_route_post_confirm_notice"
-LOCAL_ROUTE_HOUR_AUTOMATIC_OPTION = "🧠 Automático por turno"
-LOCAL_ROUTE_HOUR_CUSTOM_OPTION = "✍️ Escribir manualmente"
-
-
-
 USUARIOS_VALIDOS = [
     "DIANASOFIA47",
     "ALEJANDRO38",
@@ -2987,6 +2983,7 @@ with tab1:
             if is_local_recoge_aula:
                 st.session_state["local_route_hora_entrega_manual"] = ""
                 st.session_state.pop("local_route_hora_entrega_selector", None)
+                st.session_state.pop("local_route_hora_entrega_selector_prev", None)
                 st.session_state.pop("local_route_hora_entrega_custom", None)
                 st.caption(
                     "ℹ️ Para **🎓 Recoge en Aula** no se usa hoja de ruta ni actualización de `Clientes_Locales`."
@@ -3253,54 +3250,40 @@ with tab1:
             )
             if usa_logica_local and not is_local_pasa_bodega and not is_local_recoge_aula:
                 local_route_hour_options = [
+                    "",
                     "9:00 AM a 2:00 PM",
                     "3:00 PM a 7:00 PM",
-                    "10:00 AM a 7:00 PM",
                 ]
-                if not tab1_special_shipping:
-                    local_route_hour_options = [
-                        LOCAL_ROUTE_HOUR_AUTOMATIC_OPTION,
-                        LOCAL_ROUTE_HOUR_CUSTOM_OPTION,
-                        *local_route_hour_options,
-                    ]
 
                 hora_entrega_actual = str(st.session_state.get("local_route_hora_entrega_manual", "") or "").strip()
                 if hora_entrega_actual in local_route_hour_options:
                     default_hora_selector = hora_entrega_actual
-                elif hora_entrega_actual and not tab1_special_shipping:
-                    default_hora_selector = LOCAL_ROUTE_HOUR_CUSTOM_OPTION
-                elif tab1_special_shipping:
-                    default_hora_selector = local_route_hour_options[0]
                 else:
-                    default_hora_selector = LOCAL_ROUTE_HOUR_AUTOMATIC_OPTION
+                    default_hora_selector = local_route_hour_options[0]
 
                 if st.session_state.get("local_route_hora_entrega_selector") != default_hora_selector:
                     st.session_state["local_route_hora_entrega_selector"] = default_hora_selector
 
                 hora_entrega_selector = st.selectbox(
-                    "🕒 HORA DE ENTREGA",
+                    "🕒 Sugerencias de hora (opcional)",
                     local_route_hour_options,
                     key="local_route_hora_entrega_selector",
-                    help="Puedes usar una opción sugerida o elegir ✍️ Escribir manualmente para capturarla/editarla.",
+                    format_func=lambda x: "Seleccionar sugerencia..." if x == "" else x,
+                    help="Selecciona una sugerencia para autocompletar. Después puedes editar libremente el texto.",
                 )
+                hora_selector_prev = st.session_state.get("local_route_hora_entrega_selector_prev")
+                if hora_entrega_selector != hora_selector_prev:
+                    if hora_entrega_selector:
+                        st.session_state["local_route_hora_entrega_manual"] = hora_entrega_selector
+                    st.session_state["local_route_hora_entrega_selector_prev"] = hora_entrega_selector
 
-                if hora_entrega_selector == LOCAL_ROUTE_HOUR_AUTOMATIC_OPTION:
-                    st.session_state["local_route_hora_entrega_manual"] = ""
-                    local_route_hora_entrega = ""
-                    st.info("ℹ️ En 🧠 Automático por turno, la hoja de ruta escribirá: `10:00 AM a 7:00 PM`.")
-                elif hora_entrega_selector == LOCAL_ROUTE_HOUR_CUSTOM_OPTION:
-                    hora_manual_capturada = st.text_input(
-                        "✍️ Hora de entrega personalizada",
-                        value=hora_entrega_actual,
-                        key="local_route_hora_entrega_custom_input",
-                        placeholder="Ej. 11:30 AM a 4:00 PM",
-                        help="Puedes borrar, escribir o modificar libremente este texto.",
-                    ).strip()
-                    local_route_hora_entrega = hora_manual_capturada
-                    st.session_state["local_route_hora_entrega_manual"] = hora_manual_capturada
-                else:
-                    local_route_hora_entrega = hora_entrega_selector
-                    st.session_state["local_route_hora_entrega_manual"] = local_route_hora_entrega
+                local_route_hora_entrega = st.text_input(
+                    "🕒 HORA DE ENTREGA",
+                    key="local_route_hora_entrega_manual",
+                    placeholder="Ej. 11:30 AM a 4:00 PM",
+                    help="Puedes elegir una sugerencia y luego borrar, editar o escribir cualquier horario.",
+                ).strip()
+                st.session_state["local_route_hora_entrega_manual"] = local_route_hora_entrega
                 st.session_state.pop("local_route_hora_entrega_custom", None)
 
         comentario = st.text_area(


### PR DESCRIPTION
### Motivation
- Users need the `🕒 HORA DE ENTREGA` field in Tab 1 for local orders to be directly editable while still offering quick suggestions, and the previous `10:00 AM a 7:00 PM` automatic option and the separate `✍️ Escribir manualmente` mode caused confusing, non-editable behavior.

### Description
- Removed the automatic `10:00 AM a 7:00 PM` and the separate `✍️ Escribir manualmente` option and associated constants to simplify the UX. 
- Replaced the old selector flow with an optional suggestions `selectbox` (includes an empty default and suggestions `9:00 AM a 2:00 PM` and `3:00 PM a 7:00 PM`) and an always-editable `text_input` bound to `local_route_hora_entrega_manual` so the final value can be edited freely. 
- Added `local_route_hora_entrega_selector_prev` session state to detect suggestion changes and copy a chosen suggestion into the editable field only when the selection actually changes. 
- Clean up `local_route_hora_entrega_selector_prev` from session state when certain local routes (e.g., `🎓 Recoge en Aula`) disable the local route form.

### Testing
- Ran `python -m py_compile app_v.py` to verify syntax, and the file compiled successfully. 
- Verified the modified UI code paths by static inspection to ensure session-state keys and new `selectbox`/`text_input` wiring are present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d95a28e2748326a4428e65cbbc508d)