### PR TITLE
Agregar opción "Link de Pago" en Forma de Pago para vistas CDMX habilitadas

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -2833,6 +2833,7 @@ with tab1:
     tab1_use_short_mty_labels = (
         id_vendedor_tab1 in LOCAL_TURNO_CDMX_IDS or tab1_is_dual_view_user
     )
+    tab1_enable_link_pago_option = id_vendedor_tab1 in LOCAL_TURNO_CDMX_IDS
     tab1_view_mode_key = "tab1_shipping_view_mode"
     if tab1_is_dual_view_user:
         current_view_mode = st.session_state.get(tab1_view_mode_key, "mty")
@@ -2854,6 +2855,8 @@ with tab1:
         current_view_mode = "mty"
 
     tab1_special_shipping = current_view_mode == "cdmx"
+    if tab1_special_shipping and tab1_is_dual_view_user:
+        tab1_enable_link_pago_option = True
     if tab1_special_shipping:
         tipo_envio_options = [
             "🚚 Foráneo CDMX",
@@ -3402,9 +3405,16 @@ with tab1:
                 with col1:
                     fecha_pago = st.date_input("📅 Fecha del Pago", value=datetime.today().date(), key="fecha_pago_input")
                 with col2:
-                    forma_pago = st.selectbox("💳 Forma de Pago", [
-                        "Transferencia", "Depósito en Efectivo", "Tarjeta de Débito", "Tarjeta de Crédito", "Cheque"
-                    ], key="forma_pago_input")
+                    forma_pago_options = [
+                        "Transferencia",
+                        "Depósito en Efectivo",
+                        "Tarjeta de Débito",
+                        "Tarjeta de Crédito",
+                        "Cheque",
+                    ]
+                    if tab1_enable_link_pago_option:
+                        forma_pago_options.append("Link de Pago")
+                    forma_pago = st.selectbox("💳 Forma de Pago", forma_pago_options, key="forma_pago_input")
                 with col3:
                     monto_pago = st.number_input("💲 Monto del Pago", min_value=0.0, format="%.2f", key="monto_pago_input")
 
@@ -3642,9 +3652,16 @@ with tab1:
                 with col1:
                     fecha_pago = st.date_input("📅 Fecha del Pago", value=datetime.today().date(), key="fecha_pago_input")
                 with col2:
-                    forma_pago = st.selectbox("💳 Forma de Pago", [
-                        "Transferencia", "Depósito en Efectivo", "Tarjeta de Débito", "Tarjeta de Crédito", "Cheque"
-                    ], key="forma_pago_input")
+                    forma_pago_options = [
+                        "Transferencia",
+                        "Depósito en Efectivo",
+                        "Tarjeta de Débito",
+                        "Tarjeta de Crédito",
+                        "Cheque",
+                    ]
+                    if tab1_enable_link_pago_option:
+                        forma_pago_options.append("Link de Pago")
+                    forma_pago = st.selectbox("💳 Forma de Pago", forma_pago_options, key="forma_pago_input")
                 with col3:
                     monto_pago = st.number_input("💲 Monto del Pago", min_value=0.0, format="%.2f", key="monto_pago_input")
 


### PR DESCRIPTION
### Motivation
- Permitir seleccionar la nueva forma de pago "Link de Pago" solo para vendedores autorizados en la vista CDMX y mantener el formulario consistente entre flujos.

### Description
- Se añadió la bandera `tab1_enable_link_pago_option` en `app_v.py` para controlar cuándo mostrar la opción `"Link de Pago"` en el selector de `💳 Forma de Pago`.
- La opción se activa por defecto para los IDs `RUBEN67`, `JUAN24` y `FRANKO95` (variable `LOCAL_TURNO_CDMX_IDS`).
- También se habilita cuando los usuarios en `TAB1_DUAL_VIEW_IDS` (`ALEJANDRO38`, `CECILIA94`) cambian a la `Vista vendedores CDMX` (`current_view_mode == 'cdmx'`).
- Se actualizaron ambos bloques del expander `🧾 Detalles del Pago (opcional)` para construir dinámicamente la lista `forma_pago_options` y añadir `"Link de Pago"` solo cuando aplica.

### Testing
- Compilación sintáctica verificada con `python -m py_compile app_v.py`, resultado exitoso.
- No se ejecutaron pruebas UI automatizadas en este entorno.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd0a0367c8832688776479999865e6)