### PR TITLE
Enable "Link de Pago" option for CDMX vendors and dual-view users

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -2833,6 +2833,7 @@ with tab1:
     tab1_use_short_mty_labels = (
         id_vendedor_tab1 in LOCAL_TURNO_CDMX_IDS or tab1_is_dual_view_user
     )
+    tab1_enable_link_pago_option = id_vendedor_tab1 in LOCAL_TURNO_CDMX_IDS
     tab1_view_mode_key = "tab1_shipping_view_mode"
     if tab1_is_dual_view_user:
         current_view_mode = st.session_state.get(tab1_view_mode_key, "mty")
@@ -2854,6 +2855,8 @@ with tab1:
         current_view_mode = "mty"
 
     tab1_special_shipping = current_view_mode == "cdmx"
+    if tab1_special_shipping and tab1_is_dual_view_user:
+        tab1_enable_link_pago_option = True
     if tab1_special_shipping:
         tipo_envio_options = [
             "🚚 Foráneo CDMX",
@@ -3402,9 +3405,17 @@ with tab1:
                 with col1:
                     fecha_pago = st.date_input("📅 Fecha del Pago", value=datetime.today().date(), key="fecha_pago_input")
                 with col2:
-                    forma_pago = st.selectbox("💳 Forma de Pago", [
-                        "Transferencia", "Depósito en Efectivo", "Tarjeta de Débito", "Tarjeta de Crédito", "Cheque"
-                    ], key="forma_pago_input")
+                    forma_pago_options = [
+                        "Transferencia",
+                        "Efectivo",
+                        "Depósito en Efectivo",
+                        "Tarjeta de Débito",
+                        "Tarjeta de Crédito",
+                        "Cheque",
+                    ]
+                    if tab1_enable_link_pago_option:
+                        forma_pago_options.append("Link de Pago")
+                    forma_pago = st.selectbox("💳 Forma de Pago", forma_pago_options, key="forma_pago_input")
                 with col3:
                     monto_pago = st.number_input("💲 Monto del Pago", min_value=0.0, format="%.2f", key="monto_pago_input")
 
@@ -3642,9 +3653,17 @@ with tab1:
                 with col1:
                     fecha_pago = st.date_input("📅 Fecha del Pago", value=datetime.today().date(), key="fecha_pago_input")
                 with col2:
-                    forma_pago = st.selectbox("💳 Forma de Pago", [
-                        "Transferencia", "Depósito en Efectivo", "Tarjeta de Débito", "Tarjeta de Crédito", "Cheque"
-                    ], key="forma_pago_input")
+                    forma_pago_options = [
+                        "Transferencia",
+                        "Efectivo",
+                        "Depósito en Efectivo",
+                        "Tarjeta de Débito",
+                        "Tarjeta de Crédito",
+                        "Cheque",
+                    ]
+                    if tab1_enable_link_pago_option:
+                        forma_pago_options.append("Link de Pago")
+                    forma_pago = st.selectbox("💳 Forma de Pago", forma_pago_options, key="forma_pago_input")
                 with col3:
                     monto_pago = st.number_input("💲 Monto del Pago", min_value=0.0, format="%.2f", key="monto_pago_input")
 


### PR DESCRIPTION
### Motivation
- Allow CDMX-local vendors and users in the dual-view CDMX mode to select a "Link de Pago" payment method in the order capture UI.
- Normalize and expand the available payment method options to include an explicit "Efectivo" choice.

### Description
- Adds a new `tab1_enable_link_pago_option` flag computed from `id_vendedor_tab1 in LOCAL_TURNO_CDMX_IDS` and enabled also when `tab1_special_shipping and tab1_is_dual_view_user`.
- Replaces the previous hardcoded `selectbox` lists with a `forma_pago_options` list that includes "Transferencia", "Efectivo", "Depósito en Efectivo", card, and cheque options, and conditionally appends "Link de Pago" when `tab1_enable_link_pago_option` is true.
- Applies the consolidated `forma_pago_options` into both payment-detail blocks where the payment method `selectbox` is rendered.

### Testing
- No new automated tests were added for this UI change.
- The existing automated test suite was executed against the modified code and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd0a0367c8832688776479999865e6)