### PR TITLE
Add filtered Excel sheets and localized filename for Ventas export

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -4946,7 +4946,11 @@ if tab_ventas_reportes is not None:
                     "Hora_Registro",
                     "Comprobante_Confirmado",
                 ]
-                df_ventas_excel = df_ventas[columnas_excel_orden].rename(columns=columnas_excel_map)
+
+                def _df_excel_desde_base(df_base: pd.DataFrame) -> pd.DataFrame:
+                    return df_base[columnas_excel_orden].rename(columns=columnas_excel_map)
+
+                df_ventas_excel = _df_excel_desde_base(df_ventas)
                 df_ventas_excel.to_excel(writer, index=False, sheet_name="Ventas_Reportes")
                 ws = writer.sheets["Ventas_Reportes"]
 
@@ -5040,10 +5044,41 @@ if tab_ventas_reportes is not None:
                     celda_monto.font = font_negrita
                     if monto != "":
                         celda_monto.number_format = '"$"#,##0.00'
+
+                secciones_hojas = [
+                    ("Transferencia", forma_pago_norm.eq(_norm_texto("Transferencia"))),
+                    ("TC", forma_pago_norm.eq(_norm_texto("Tarjeta de Crédito"))),
+                    ("TD", forma_pago_norm.eq(_norm_texto("Tarjeta de Débito"))),
+                    ("Efectivo", forma_pago_norm.eq(_norm_texto("Efectivo"))),
+                    ("Link", forma_pago_norm.eq(_norm_texto("Link de Pago"))),
+                    ("Deposito", forma_pago_norm.eq(_norm_texto("Depósito en Efectivo"))),
+                    ("Ruben", vendedor_norm.eq(_norm_texto("RUBEN"))),
+                    ("Juan", vendedor_norm.eq(_norm_texto("JUAN"))),
+                    ("Cursos", tipo_envio_norm.eq(_norm_texto("🎓 Cursos y Eventos"))),
+                ]
+
+                for nombre_hoja, mascara in secciones_hojas:
+                    df_seccion = _df_excel_desde_base(df_ventas[mascara].copy())
+                    df_seccion.to_excel(writer, index=False, sheet_name=nombre_hoja)
+
+            month_names_es = {
+                1: "Enero", 2: "Febrero", 3: "Marzo", 4: "Abril", 5: "Mayo", 6: "Junio",
+                7: "Julio", 8: "Agosto", 9: "Septiembre", 10: "Octubre", 11: "Noviembre", 12: "Diciembre",
+            }
+            if filtro_mes != "Todos":
+                try:
+                    anio, mes = filtro_mes.split("-")
+                    nombre_mes = month_names_es.get(int(mes), mes)
+                    nombre_archivo = f"Ventas {nombre_mes} {anio}.xlsx"
+                except (ValueError, AttributeError):
+                    nombre_archivo = f"ventas_reportes_{datetime.now().strftime('%Y%m%d_%H%M%S')}.xlsx"
+            else:
+                nombre_archivo = "Ventas Totales.xlsx"
+
             st.download_button(
                 label="📥 Descargar ventas (Excel)",
                 data=ventas_excel_buffer.getvalue(),
-                file_name=f"ventas_reportes_{datetime.now().strftime('%Y%m%d_%H%M%S')}.xlsx",
+                file_name=nombre_archivo,
                 mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
                 key="tab_reportes_descargar_ventas_excel",
             )


### PR DESCRIPTION
### Motivation
- Improve the Excel export for the ventas report by producing separate sheets for common payment types, vendors and courses and by producing a human-friendly localized filename when a month filter is applied.
- Reduce duplication when preparing DataFrame slices for Excel and add small normalization helpers to make filters robust.

### Description
- Introduced helper ` _df_excel_desde_base(df_base: pd.DataFrame)` to centralize the construction/renaming of the Excel-ready DataFrame and replaced the inline slice with calls to this helper. 
- Added helper functions ` _monto_columna`, ` _col_texto`, and ` _norm_texto` to normalize numeric and text columns and to handle missing columns safely. 
- Created `secciones_hojas` and iterate to write additional workbook sheets for filters such as `Transferencia`, `TC`, `TD`, `Efectivo`, `Link`, `Deposito`, `Ruben`, `Juan`, and `Cursos` using the normalized masks. 
- Implemented Spanish month name mapping `month_names_es` and logic to build a localized `nombre_archivo` when `filtro_mes` is not `"Todos"`, with a fallback to a timestamped filename on parse errors, and replaced the previous timestamp-only filename in `st.download_button` with `nombre_archivo`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd16d2d7e0832692ca20be6de6e751)