### PR TITLE
Quitar usuario JOSE y mostrar nombre de vendedor en la bienvenida

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -159,7 +159,6 @@ USUARIOS_VALIDOS = [
     "CARITO82",
     "GLORIA53",
     "JUAN24",
-    "JOSE31",
     "KAREN58",
     "PAULINA57",
     "RUBEN67",
@@ -178,7 +177,6 @@ VENDEDOR_NOMBRE_POR_ID = {
     "CARITO82": "GRISELDA CAROLINA SANCHEZ GARCIA",
     "GLORIA53": "GLORIA MICHELLE GARCIA TORRES",
     "JUAN24": "JUAN CASTILLEJO",
-    "JOSE31": "JOSE CORTES",
     "KAREN58": "KAREN JAQUELINE",
     "PAULINA57": "PAULINA TREJO",
     "RUBEN67": "RUBEN",
@@ -2129,7 +2127,8 @@ if s3_status and not s3_status.get("ok", False):
         st.rerun()
     st.stop()
 
-st.markdown(f"### 👋 Bienvenido, {usuario_activo}")
+nombre_vendedor_activo = get_session_vendedor_name() or usuario_activo
+st.markdown(f"### 👋 Bienvenido, {nombre_vendedor_activo}")
 
 st.markdown(
     """
@@ -2797,7 +2796,6 @@ VENDEDORES_LIST = sorted([
     "DISTRIBUCION Y UNIVERSIDADES",
     "GLORIA MICHELLE GARCIA TORRES",
     "GRISELDA CAROLINA SANCHEZ GARCIA",
-    "JOSE CORTES",
     "JUAN CASTILLEJO",
     "KAREN JAQUELINE",
     "PAULINA TREJO",


### PR DESCRIPTION
### Motivation
- Eliminar el acceso y rastro del usuario José para que ya no pueda autenticarse ni aparecer como vendedor en la UI.
- Mejorar la claridad de la pantalla de bienvenida mostrando el nombre del vendedor asociado al usuario autenticado en vez de solo el ID.

### Description
- Eliminé `"JOSE31"` de la lista `USUARIOS_VALIDOS` en `app_v.py` para revocar su acceso de inicio de sesión.
- Eliminé el mapeo `"JOSE31": "JOSE CORTES"` de `VENDEDOR_NOMBRE_POR_ID` para quitar la asociación ID→nombre.
- Quité `"JOSE CORTES"` de `VENDEDORES_LIST` para que no aparezca en el selector de vendedores.
- Reemplacé la línea de bienvenida para usar `get_session_vendedor_name()` y asignar `nombre_vendedor_activo = get_session_vendedor_name() or usuario_activo`, y luego mostrar `nombre_vendedor_activo` en el encabezado.

### Testing
- Ejecuté la verificación de sintaxis con `python -m py_compile app_v.py` y la comprobación pasó sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd34d803448326b8b77ccd8489a69f)