### PR TITLE
Add structured parsing, editor and Word formatting for Material_Devuelto

### DIFF
--- a/app_admin.py
+++ b/app_admin.py
@@ -128,6 +128,65 @@ def normalize_estado_entrega(value) -> str:
     return raw
 
 
+MATERIAL_ROW_PATTERN = re.compile(
+    r"^\s*(?P<codigo>[A-Za-z0-9\-]+)\s+(?P<resto>.+?)\s*$"
+)
+MATERIAL_QTY_PATTERN = re.compile(r"\((?P<cantidad>\d+)\s*unidad(?:es)?\)", re.IGNORECASE)
+MATERIAL_AMOUNT_PATTERN = re.compile(r"\$\s*(?P<monto>[\d,]+(?:\.\d{1,2})?)\s*$")
+
+
+def parse_material_lines(raw_text: str) -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
+    for raw_line in str(raw_text or "").splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+
+        codigo = ""
+        descripcion = line
+        cantidad = ""
+        monto = ""
+
+        amount_match = MATERIAL_AMOUNT_PATTERN.search(line)
+        if amount_match:
+            monto = amount_match.group("monto").replace(",", "")
+            line = line[:amount_match.start()].strip()
+
+        qty_match = MATERIAL_QTY_PATTERN.search(line)
+        if qty_match:
+            cantidad = qty_match.group("cantidad")
+            line = (line[:qty_match.start()] + line[qty_match.end():]).strip()
+
+        row_match = MATERIAL_ROW_PATTERN.match(line)
+        if row_match:
+            codigo = row_match.group("codigo").strip().upper()
+            descripcion = row_match.group("resto").strip()
+        else:
+            descripcion = line
+
+        rows.append(
+            {
+                "Código": codigo or "N/A",
+                "Descripción": descripcion or "N/A",
+                "Cantidad": cantidad or "N/A",
+                "Monto IVA": (f"${float(monto):,.2f}" if monto else "N/A"),
+            }
+        )
+    return rows
+
+
+def format_material_for_word(raw_text: str) -> str:
+    rows = parse_material_lines(raw_text)
+    if not rows:
+        return str(raw_text or "").strip() or "Sin registro"
+    lines = ["Código | Descripción | Cantidad | Monto IVA"]
+    for row in rows:
+        lines.append(
+            f"{row['Código']} | {row['Descripción']} | {row['Cantidad']} | {row['Monto IVA']}"
+        )
+    return "\n".join(lines)
+
+
 def normalize_user_field(value: str | None) -> str:
     """Normaliza campos de usuario para mostrarlos solo si traen información."""
     raw = str(value or "").strip()
@@ -5003,7 +5062,11 @@ with tab3, suppress(StopException):
             st.info(__s(row.get("Motivo_Detallado","")))
         if __has(row.get("Material_Devuelto","")):
             st.markdown("**📦 Piezas / Material:**")
-            st.info(__s(row.get("Material_Devuelto","")))
+            material_txt = __s(row.get("Material_Devuelto",""))
+            st.info(material_txt)
+            material_rows = parse_material_lines(material_txt)
+            if material_rows:
+                st.dataframe(pd.DataFrame(material_rows), use_container_width=True, hide_index=True)
         if __has(row.get("Monto_Devuelto","")):
             st.markdown(f"**💵 Monto (dev./estimado):** {row.get('Monto_Devuelto')}")
 
@@ -5472,8 +5535,9 @@ with tab3, suppress(StopException):
                     doc = Document(template_path)
 
                     # Mapping exacto a placeholders del .docx
+                    material_devuelto_word = format_material_for_word(row.get("Material_Devuelto"))
                     mapping = {
-                        "Material_Devuelto": _safe_value(row.get("Material_Devuelto")),
+                        "Material_Devuelto": material_devuelto_word,
                         "Cliente": _safe_value(row.get("Cliente")),
                         "Vendedor_Registro": _safe_value(row.get("Vendedor_Registro")),
                         "Folio_Factura": _safe_value(row.get("Folio_Factura")),

--- a/app_v.py
+++ b/app_v.py
@@ -75,6 +75,9 @@ TAB1_FORM_STATE_KEYS_TO_CLEAR: set[str] = {
     "area_responsable",
     "nombre_responsable",
     "motivo_detallado",
+    "material_devuelto_editor_seed",
+    "material_devuelto_editor_rows",
+    "material_devuelto_editor",
     "g_resultado_esperado",
     "g_descripcion_falla",
     "g_piezas_afectadas",
@@ -209,6 +212,124 @@ def normalize_case_amount(value, placeholder: str = "N/A") -> str:
     except (TypeError, ValueError):
         return placeholder
     return f"{amount:.2f}" if amount > 0 else placeholder
+
+
+MATERIAL_ROW_PATTERN = re.compile(
+    r"^\s*(?P<codigo>[A-Za-z0-9\-]+)\s+(?P<resto>.+?)\s*$"
+)
+MATERIAL_QTY_PATTERN = re.compile(r"\((?P<cantidad>\d+)\s*unidad(?:es)?\)", re.IGNORECASE)
+MATERIAL_AMOUNT_PATTERN = re.compile(r"\$\s*(?P<monto>[\d,]+(?:\.\d{1,2})?)\s*$")
+
+
+def parse_material_lines(raw_text: str) -> List[Dict[str, str]]:
+    """Parse multiline devolución material text into structured rows."""
+    rows: List[Dict[str, str]] = []
+    for raw_line in str(raw_text or "").splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+
+        codigo = ""
+        descripcion = line
+        cantidad = ""
+        monto = ""
+
+        amount_match = MATERIAL_AMOUNT_PATTERN.search(line)
+        if amount_match:
+            monto = amount_match.group("monto").replace(",", "")
+            line = line[:amount_match.start()].strip()
+
+        qty_match = MATERIAL_QTY_PATTERN.search(line)
+        if qty_match:
+            cantidad = qty_match.group("cantidad")
+            line = (line[:qty_match.start()] + line[qty_match.end():]).strip()
+
+        row_match = MATERIAL_ROW_PATTERN.match(line)
+        if row_match:
+            codigo = row_match.group("codigo").strip().upper()
+            descripcion = row_match.group("resto").strip()
+        else:
+            descripcion = line
+
+        rows.append(
+            {
+                "Código": codigo or "N/A",
+                "Descripción": descripcion or "N/A",
+                "Cantidad": cantidad or "N/A",
+                "Monto IVA": (f"${float(monto):,.2f}" if monto else "N/A"),
+            }
+        )
+    return rows
+
+
+def format_material_rows_for_storage(rows: List[Dict[str, str]]) -> str:
+    """Serialize material rows to canonical storage format."""
+    if not rows:
+        return "N/A"
+    lines = ["Código | Descripción | Cantidad | Monto IVA"]
+    for row in rows:
+        lines.append(
+            f"{row['Código']} | {row['Descripción']} | {row['Cantidad']} | {row['Monto IVA']}"
+        )
+    return "\n".join(lines)
+
+
+def format_material_for_storage(raw_text: str) -> str:
+    """Return canonical text format so other apps can parse consistently."""
+    rows = parse_material_lines(raw_text)
+    if not rows:
+        return normalize_case_text(raw_text)
+    return format_material_rows_for_storage(rows)
+
+
+def get_material_rows_for_editor(raw_text: str) -> List[Dict[str, str]]:
+    rows = parse_material_lines(raw_text)
+    if rows:
+        return rows
+    return [{"Código": "", "Descripción": "", "Cantidad": "", "Monto IVA": ""}]
+
+
+def sanitize_material_editor_rows(edited_df: pd.DataFrame) -> List[Dict[str, str]]:
+    cleaned_rows: List[Dict[str, str]] = []
+    for _, row in edited_df.iterrows():
+        codigo = str(row.get("Código", "") or "").strip().upper()
+        descripcion = str(row.get("Descripción", "") or "").strip()
+        cantidad_raw = str(row.get("Cantidad", "") or "").strip()
+        monto_raw = str(row.get("Monto IVA", "") or "").strip().replace("$", "").replace(",", "")
+
+        if not any([codigo, descripcion, cantidad_raw, monto_raw]):
+            continue
+
+        cantidad = "N/A"
+        if cantidad_raw:
+            try:
+                cantidad_int = int(float(cantidad_raw))
+                cantidad = str(cantidad_int) if cantidad_int >= 0 else "N/A"
+            except ValueError:
+                cantidad = cantidad_raw
+
+        monto = "N/A"
+        if monto_raw:
+            try:
+                monto = f"${float(monto_raw):,.2f}"
+            except ValueError:
+                monto = str(row.get("Monto IVA", "") or "").strip() or "N/A"
+
+        cleaned_rows.append(
+            {
+                "Código": codigo or "N/A",
+                "Descripción": descripcion or "N/A",
+                "Cantidad": cantidad,
+                "Monto IVA": monto,
+            }
+        )
+    return cleaned_rows
+
+
+def show_material_table(raw_text: str) -> None:
+    rows = parse_material_lines(raw_text)
+    if rows:
+        st.dataframe(pd.DataFrame(rows), use_container_width=True, hide_index=True)
 
 
 def format_estado_entrega(value) -> str:
@@ -3509,10 +3630,35 @@ with tab1:
                 key="resultado_esperado"
             )
 
-            material_devuelto = st.text_area(
-                "📦 Material a Devolver (códigos, descripciones, cantidades y monto individual con IVA)",
-                key="material_devuelto"
+            st.markdown("#### 📦 Material a Devolver (captura por renglón)")
+            st.caption("Agrega una fila por producto para evitar mezclas de código, descripción, cantidad y monto.")
+            material_seed = st.session_state.get("material_devuelto", "")
+            if "material_devuelto_editor_seed" not in st.session_state:
+                st.session_state["material_devuelto_editor_seed"] = material_seed
+            if "material_devuelto_editor_rows" not in st.session_state:
+                st.session_state["material_devuelto_editor_rows"] = get_material_rows_for_editor(material_seed)
+
+            if material_seed != st.session_state.get("material_devuelto_editor_seed", "") and material_seed.strip():
+                st.session_state["material_devuelto_editor_rows"] = get_material_rows_for_editor(material_seed)
+                st.session_state["material_devuelto_editor_seed"] = material_seed
+
+            material_editor_df = st.data_editor(
+                pd.DataFrame(st.session_state.get("material_devuelto_editor_rows", [])),
+                key="material_devuelto_editor",
+                num_rows="dynamic",
+                hide_index=True,
+                use_container_width=True,
+                column_config={
+                    "Código": st.column_config.TextColumn("Código", help="Ejemplo: TOR-208"),
+                    "Descripción": st.column_config.TextColumn("Descripción"),
+                    "Cantidad": st.column_config.NumberColumn("Cantidad", min_value=0, step=1, format="%d"),
+                    "Monto IVA": st.column_config.TextColumn("Monto IVA", help="Ejemplo: 5719.96 o $5,719.96"),
+                },
             )
+            material_rows_clean = sanitize_material_editor_rows(material_editor_df)
+            st.session_state["material_devuelto_editor_rows"] = material_rows_clean
+            material_devuelto = format_material_rows_for_storage(material_rows_clean)
+            st.session_state["material_devuelto"] = material_devuelto
 
             monto_devuelto = st.number_input(
                 "💲 Total de Materiales a Devolver (con IVA)",
@@ -4331,7 +4477,7 @@ with tab1:
             # Normalización de campos para Casos Especiales
             if tipo_envio == "🔁 Devolución":
                 resultado_esperado = normalize_case_text(resultado_esperado)
-                material_devuelto = normalize_case_text(material_devuelto)
+                material_devuelto = format_material_for_storage(material_devuelto)
                 motivo_detallado = normalize_case_text(motivo_detallado)
                 nombre_responsable = normalize_case_text(nombre_responsable)
             if tipo_envio == "🛠 Garantía":
@@ -8271,7 +8417,9 @@ def render_caso_especial_busqueda(res):
         st.info(str(res.get("Motivo_Detallado", "")).strip())
     if str(res.get("Material_Devuelto", "")).strip():
         st.markdown("**📦 Piezas / Material:**")
-        st.info(str(res.get("Material_Devuelto", "")).strip())
+        material_text = str(res.get("Material_Devuelto", "")).strip()
+        st.info(material_text)
+        show_material_table(material_text)
     if str(res.get("Monto_Devuelto", "")).strip():
         st.markdown(f"**💵 Monto (dev./estimado):** {res.get('Monto_Devuelto', '')}")
 


### PR DESCRIPTION
### Motivation
- Normalize free-text `Material_Devuelto` entries into a structured, canonical format to avoid mixed codes/descriptions in a single text area.
- Provide an interactive editor to capture material rows reliably and sanitize user edits before storing.
- Improve administrative UX by showing parsed material in a table and producing a clean, human-readable block for Word export.

### Description
- Added regex patterns and a reusable parser `parse_material_lines` to extract `Código`, `Descripción`, `Cantidad` and `Monto IVA` from multiline material text in both `app_v.py` and `app_admin.py`.
- Implemented helper formatters: `format_material_rows_for_storage`, `format_material_for_storage`, `format_material_for_word`, `get_material_rows_for_editor`, and `sanitize_material_editor_rows` to serialize/deserialize rows and normalize values.
- Replaced the free `st.text_area` for devolución material input with a dynamic `st.data_editor` grid and session-state glue (`material_devuelto_editor_seed`, `material_devuelto_editor_rows`, `material_devuelto_editor`) in `app_v.py`, and convert edits into the canonical storage string `material_devuelto`.
- In admin views (`app_admin.py` and `app_v.py`), show parsed material as a `st.dataframe` and use `format_material_for_word` to populate the `Material_Devuelto` placeholder when generating the Word `Formato_Devolución-M.docx` export.

### Testing
- No automated tests were added or modified for this change and no automated test suite was run as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd4c6ab254832693e1850f36cab1f5)