### PR TITLE
Fix Streamlit form_submit_button TypeError in tab3 confirm form

### DIFF
--- a/app_admin.py
+++ b/app_admin.py
@@ -5456,7 +5456,6 @@ with tab3, suppress(StopException):
         submitted = st.form_submit_button(
             "💾 Guardar Confirmación",
             use_container_width=True,
-            key=f"tab3_submit_{row.get('ID_Pedido','')}",
         )
 
     # Helper para construir updates


### PR DESCRIPTION
### Motivation
- Passing a `key` to `st.form_submit_button` caused a `TypeError` and the “Missing Submit Button” warning in some Streamlit environments, which prevented the tab3 confirmation form from registering the submit button.

### Description
- Remove the `key` argument from the `st.form_submit_button` call in the `tab3_confirm_form` within `app_admin.py` so the submit button registers correctly without changing any business logic; for per-case uniqueness keep keys on the `st.form` or on internal widgets instead.

### Testing
- `python -m py_compile app_admin.py` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd7057d9e48326aa091e2d7e5d7a31)