### PR TITLE
Fix devolución material editor placeholders blocking input

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -298,8 +298,12 @@ def format_material_rows_for_storage(rows: List[Dict[str, str]]) -> str:
         return "N/A"
     lines = ["Código | Descripción | Cantidad | Monto IVA"]
     for row in rows:
+        codigo = str(row.get("Código", "") or "").strip() or "N/A"
+        descripcion = str(row.get("Descripción", "") or "").strip() or "N/A"
+        cantidad = str(row.get("Cantidad", "") or "").strip() or "N/A"
+        monto = str(row.get("Monto IVA", "") or "").strip() or "N/A"
         lines.append(
-            f"{row['Código']} | {row['Descripción']} | {row['Cantidad']} | {row['Monto IVA']}"
+            f"{codigo} | {descripcion} | {cantidad} | {monto}"
         )
     return "\n".join(lines)
 
@@ -315,7 +319,17 @@ def format_material_for_storage(raw_text: str) -> str:
 def get_material_rows_for_editor(raw_text: str) -> List[Dict[str, str]]:
     rows = parse_material_lines(raw_text)
     if rows:
-        return rows
+        normalized_rows: List[Dict[str, str]] = []
+        for row in rows:
+            normalized_rows.append(
+                {
+                    "Código": "" if str(row.get("Código", "")).strip().upper() == "N/A" else str(row.get("Código", "") or "").strip().upper(),
+                    "Descripción": "" if str(row.get("Descripción", "")).strip().upper() == "N/A" else str(row.get("Descripción", "") or "").strip(),
+                    "Cantidad": "" if str(row.get("Cantidad", "")).strip().upper() == "N/A" else str(row.get("Cantidad", "") or "").strip(),
+                    "Monto IVA": "" if str(row.get("Monto IVA", "")).strip().upper() == "N/A" else str(row.get("Monto IVA", "") or "").strip(),
+                }
+            )
+        return normalized_rows
     return [{"Código": "", "Descripción": "", "Cantidad": "", "Monto IVA": ""}]
 
 
@@ -330,25 +344,25 @@ def sanitize_material_editor_rows(edited_df: pd.DataFrame) -> List[Dict[str, str
         if not any([codigo, descripcion, cantidad_raw, monto_raw]):
             continue
 
-        cantidad = "N/A"
+        cantidad = ""
         if cantidad_raw:
             try:
                 cantidad_int = int(float(cantidad_raw))
-                cantidad = str(cantidad_int) if cantidad_int >= 0 else "N/A"
+                cantidad = str(cantidad_int) if cantidad_int >= 0 else ""
             except ValueError:
-                cantidad = cantidad_raw
+                cantidad = ""
 
-        monto = "N/A"
+        monto = ""
         if monto_raw:
             try:
                 monto = f"${float(monto_raw):,.2f}"
             except ValueError:
-                monto = str(row.get("Monto IVA", "") or "").strip() or "N/A"
+                monto = ""
 
         cleaned_rows.append(
             {
-                "Código": codigo or "N/A",
-                "Descripción": descripcion or "N/A",
+                "Código": codigo or "",
+                "Descripción": descripcion or "",
                 "Cantidad": cantidad,
                 "Monto IVA": monto,
             }


### PR DESCRIPTION
### Motivation
- The editable "Material a Devolver" table was initialized with `N/A` placeholders which made numeric cells (especially `Cantidad`) become invalid and blocked user input in the `data_editor` UI.
- Existing storage format expects `N/A` for empty values, but the editor should receive empty strings so users can type without the field being forced to an invalid state.
- The change keeps persisted data compatible while fixing the editing UX issue.

### Description
- Normalize parsed rows for the editor in `get_material_rows_for_editor` by converting `"N/A"` placeholders to empty strings and normalizing casing for `Código` and other fields so the `data_editor` receives editable values instead of `N/A`.
- Update `sanitize_material_editor_rows` to keep optional fields (`Cantidad`, `Monto IVA`, `Código`, `Descripción`) as empty strings when empty/invalid instead of forcing `N/A`, preventing invalid typed states in numeric columns.
- Ensure canonical persisted format is preserved by converting empty values back to `N/A` during serialization in `format_material_rows_for_storage`.

### Testing
- Ran `python -m py_compile app_v.py` and it completed successfully.
- No additional automated unit tests were run in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de59bcde9c8326a90dace0dd5d2714)