### PR TITLE
Normalize material-editor data, tighten material formatting, and adjust tab1 state key handling

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -77,10 +77,8 @@ TAB1_FORM_STATE_KEYS_TO_CLEAR: set[str] = {
     "motivo_detallado",
     "material_devuelto_editor_seed",
     "material_devuelto_editor_rows",
-    "material_devuelto_editor",
     "g_piezas_editor_seed",
     "g_piezas_editor_rows",
-    "g_piezas_editor",
     "g_resultado_esperado",
     "g_descripcion_falla",
     "g_piezas_afectadas",
@@ -137,6 +135,8 @@ TAB1_RESTORE_EXCLUDED_KEYS: set[str] = {
     "pedido_adjuntos",
     "comprobante_cliente",
     "comprobante_uploader_final",
+    "material_devuelto_editor",
+    "g_piezas_editor",
 }
 
 TAB1_SCROLL_RESTORE_FLAG_KEY = "tab1_restore_scroll_after_submit"
@@ -298,8 +298,12 @@ def format_material_rows_for_storage(rows: List[Dict[str, str]]) -> str:
         return "N/A"
     lines = ["Código | Descripción | Cantidad | Monto IVA"]
     for row in rows:
+        codigo = str(row.get("Código", "") or "").strip() or "N/A"
+        descripcion = str(row.get("Descripción", "") or "").strip() or "N/A"
+        cantidad = str(row.get("Cantidad", "") or "").strip() or "N/A"
+        monto = str(row.get("Monto IVA", "") or "").strip() or "N/A"
         lines.append(
-            f"{row['Código']} | {row['Descripción']} | {row['Cantidad']} | {row['Monto IVA']}"
+            f"{codigo} | {descripcion} | {cantidad} | {monto}"
         )
     return "\n".join(lines)
 
@@ -315,7 +319,17 @@ def format_material_for_storage(raw_text: str) -> str:
 def get_material_rows_for_editor(raw_text: str) -> List[Dict[str, str]]:
     rows = parse_material_lines(raw_text)
     if rows:
-        return rows
+        normalized_rows: List[Dict[str, str]] = []
+        for row in rows:
+            normalized_rows.append(
+                {
+                    "Código": "" if str(row.get("Código", "")).strip().upper() == "N/A" else str(row.get("Código", "") or "").strip().upper(),
+                    "Descripción": "" if str(row.get("Descripción", "")).strip().upper() == "N/A" else str(row.get("Descripción", "") or "").strip(),
+                    "Cantidad": "" if str(row.get("Cantidad", "")).strip().upper() == "N/A" else str(row.get("Cantidad", "") or "").strip(),
+                    "Monto IVA": "" if str(row.get("Monto IVA", "")).strip().upper() == "N/A" else str(row.get("Monto IVA", "") or "").strip(),
+                }
+            )
+        return normalized_rows
     return [{"Código": "", "Descripción": "", "Cantidad": "", "Monto IVA": ""}]
 
 
@@ -330,25 +344,25 @@ def sanitize_material_editor_rows(edited_df: pd.DataFrame) -> List[Dict[str, str
         if not any([codigo, descripcion, cantidad_raw, monto_raw]):
             continue
 
-        cantidad = "N/A"
+        cantidad = ""
         if cantidad_raw:
             try:
                 cantidad_int = int(float(cantidad_raw))
-                cantidad = str(cantidad_int) if cantidad_int >= 0 else "N/A"
+                cantidad = str(cantidad_int) if cantidad_int >= 0 else ""
             except ValueError:
-                cantidad = cantidad_raw
+                cantidad = ""
 
-        monto = "N/A"
+        monto = ""
         if monto_raw:
             try:
                 monto = f"${float(monto_raw):,.2f}"
             except ValueError:
-                monto = str(row.get("Monto IVA", "") or "").strip() or "N/A"
+                monto = ""
 
         cleaned_rows.append(
             {
-                "Código": codigo or "N/A",
-                "Descripción": descripcion or "N/A",
+                "Código": codigo or "",
+                "Descripción": descripcion or "",
                 "Cantidad": cantidad,
                 "Monto IVA": monto,
             }


### PR DESCRIPTION
### Motivation
- Ensure material rows are consistently normalized for storage and editor UI, avoiding literal "N/A" values leaking into editors or storage formats.
- Standardize empty/value handling (quantities and amounts) and prevent invalid values from being persisted.
- Move editor-related keys from the form-clear set to the restore-excluded set so editor state is preserved on restore.

### Description
- Moved `"material_devuelto_editor"` and `"g_piezas_editor"` from `TAB1_FORM_STATE_KEYS_TO_CLEAR` into `TAB1_RESTORE_EXCLUDED_KEYS` so editor payloads are not cleared but excluded from restore processing.
- Updated `format_material_rows_for_storage` to defensively read and `strip()` each column value and fall back to `"N/A"` for storage only when appropriate to avoid KeyError and inconsistent formatting.
- Changed `get_material_rows_for_editor` to return normalized editor rows that convert stored `"N/A"` tokens to empty strings and normalize code casing for editor consumption.
- Modified `sanitize_material_editor_rows` to use empty strings for missing/invalid `Cantidad` and `Monto IVA` values and to emit empty defaults for `Código` and `Descripción`, preventing `"N/A"` from being stored from user-edited data.

### Testing
- Ran the project's unit test suite covering material parsing/formatting and form state behavior, and the tests completed successfully.
- Verified that material formatting round-trips through `parse_material_lines` -> `sanitize_material_editor_rows` -> `format_material_rows_for_storage` produce normalized storage output in local test cases.
- No automated failures observed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de59bcde9c8326a90dace0dd5d2714)