### PR TITLE
Auto-calcular Total de Materiales a Devolver (Tab 1)

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -370,6 +370,21 @@ def sanitize_material_editor_rows(edited_df: pd.DataFrame) -> List[Dict[str, str
     return cleaned_rows
 
 
+def sum_material_rows_monto_iva(rows: List[Dict[str, str]]) -> float:
+    """Return total IVA amount from material rows (ignoring invalid/empty values)."""
+    total = 0.0
+    for row in rows:
+        monto_raw = str(row.get("Monto IVA", "") or "").strip()
+        if not monto_raw:
+            continue
+        monto_clean = monto_raw.replace("$", "").replace(",", "")
+        try:
+            total += float(monto_clean)
+        except ValueError:
+            continue
+    return round(total, 2)
+
+
 def show_material_table(raw_text: str) -> None:
     rows = parse_material_lines(raw_text)
     if rows:
@@ -3712,12 +3727,16 @@ with tab1:
             st.session_state["material_devuelto_editor_rows"] = material_rows_clean
             material_devuelto = format_material_rows_for_storage(material_rows_clean)
             st.session_state["material_devuelto"] = material_devuelto
+            monto_devuelto_calculado = sum_material_rows_monto_iva(material_rows_clean)
+            st.session_state["monto_devuelto"] = monto_devuelto_calculado
 
             monto_devuelto = st.number_input(
                 "💲 Total de Materiales a Devolver (con IVA)",
                 min_value=0.0,
                 format="%.2f",
-                key="monto_devuelto"
+                key="monto_devuelto",
+                disabled=True,
+                help="Se calcula automáticamente con la suma de la columna 'Monto IVA'.",
             )
 
             area_responsable = st.selectbox(


### PR DESCRIPTION
### Motivation
- Rellenar automáticamente el campo "💲 Total de Materiales a Devolver (con IVA)" al registrar un pedido con tipo de envío "🔁 Devolución" sumando la columna `Monto IVA` por renglón para evitar entradas manuales inconsistentes.

### Description
- Se agregó la función `sum_material_rows_monto_iva(rows: List[Dict[str, str]]) -> float` que suma de forma robusta los valores de la columna `Monto IVA`, ignorando celdas vacías o mal formadas.
- Se calcula `monto_devuelto_calculado = sum_material_rows_monto_iva(material_rows_clean)` después de sanear las filas y se guarda en `st.session_state["monto_devuelto"]` para mantener el estado del formulario.
- El campo de total `st.number_input("💲 Total de Materiales a Devolver (con IVA)", ...)` quedó en modo solo lectura usando `disabled=True` y se añadió un `help` que indica que el valor se calcula automáticamente.

### Testing
- Se ejecutó `python -m py_compile app_v.py` y la verificación de sintaxis fue exitosa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de5ff9af6483269ad9f79de5135673)