### PR TITLE
Sanitize material editor entries and auto-calculate Total 'Monto IVA'

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -341,6 +341,15 @@ def sanitize_material_editor_rows(edited_df: pd.DataFrame) -> List[Dict[str, str
         cantidad_raw = str(row.get("Cantidad", "") or "").strip()
         monto_raw = str(row.get("Monto IVA", "") or "").strip().replace("$", "").replace(",", "")
 
+        if codigo in {"NONE", "NAN"}:
+            codigo = ""
+        if descripcion.lower() in {"none", "nan"}:
+            descripcion = ""
+        if cantidad_raw.lower() in {"none", "nan"}:
+            cantidad_raw = ""
+        if monto_raw.lower() in {"none", "nan"}:
+            monto_raw = ""
+
         if not any([codigo, descripcion, cantidad_raw, monto_raw]):
             continue
 
@@ -368,6 +377,21 @@ def sanitize_material_editor_rows(edited_df: pd.DataFrame) -> List[Dict[str, str
             }
         )
     return cleaned_rows
+
+
+def sum_material_rows_monto_iva(rows: List[Dict[str, str]]) -> float:
+    """Return total IVA amount from material rows (ignoring invalid/empty values)."""
+    total = 0.0
+    for row in rows:
+        monto_raw = str(row.get("Monto IVA", "") or "").strip()
+        if not monto_raw:
+            continue
+        monto_clean = monto_raw.replace("$", "").replace(",", "")
+        try:
+            total += float(monto_clean)
+        except ValueError:
+            continue
+    return round(total, 2)
 
 
 def show_material_table(raw_text: str) -> None:
@@ -3712,12 +3736,15 @@ with tab1:
             st.session_state["material_devuelto_editor_rows"] = material_rows_clean
             material_devuelto = format_material_rows_for_storage(material_rows_clean)
             st.session_state["material_devuelto"] = material_devuelto
+            monto_devuelto_calculado = sum_material_rows_monto_iva(material_rows_clean)
 
             monto_devuelto = st.number_input(
                 "💲 Total de Materiales a Devolver (con IVA)",
                 min_value=0.0,
                 format="%.2f",
-                key="monto_devuelto"
+                value=float(monto_devuelto_calculado),
+                disabled=True,
+                help="Se calcula automáticamente con la suma de la columna 'Monto IVA'.",
             )
 
             area_responsable = st.selectbox(


### PR DESCRIPTION
### Motivation

- Prevent spurious `None`/`NaN` string artifacts from polluting material editor rows and stored data.
- Provide a reliable aggregated total for the `Monto IVA` column so users don't need to compute it manually.
- Improve robustness of parsing/formatting for currency-like inputs in the material editor.

### Description

- Normalize and strip sentinel values by updating `sanitize_material_editor_rows` to convert `NONE`/`NaN` (case variants) in `Código`, `Descripción`, `Cantidad`, and `Monto IVA` to empty strings before further processing.
- Add `sum_material_rows_monto_iva(rows: List[Dict[str, str]]) -> float` to parse `Monto IVA` values (handles `$` and `,` formats), sum valid numbers, and return a rounded total.
- Wire the computed total into the UI by computing `monto_devuelto_calculado` from sanitized rows and setting the `monto_devuelto` `st.number_input` to `value=float(monto_devuelto_calculado)` with `disabled=True` and a help text describing the automatic calculation.

### Testing

- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de5ff9af6483269ad9f79de5135673)