### PR TITLE
Material return editor: sanitize NAN/NONE, add IVA summation, and move editor for Devolución

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -341,6 +341,15 @@ def sanitize_material_editor_rows(edited_df: pd.DataFrame) -> List[Dict[str, str
         cantidad_raw = str(row.get("Cantidad", "") or "").strip()
         monto_raw = str(row.get("Monto IVA", "") or "").strip().replace("$", "").replace(",", "")
 
+        if codigo in {"NONE", "NAN"}:
+            codigo = ""
+        if descripcion.lower() in {"none", "nan"}:
+            descripcion = ""
+        if cantidad_raw.lower() in {"none", "nan"}:
+            cantidad_raw = ""
+        if monto_raw.lower() in {"none", "nan"}:
+            monto_raw = ""
+
         if not any([codigo, descripcion, cantidad_raw, monto_raw]):
             continue
 
@@ -368,6 +377,21 @@ def sanitize_material_editor_rows(edited_df: pd.DataFrame) -> List[Dict[str, str
             }
         )
     return cleaned_rows
+
+
+def sum_material_rows_monto_iva(rows: List[Dict[str, str]]) -> float:
+    """Return total IVA amount from material rows (ignoring invalid/empty values)."""
+    total = 0.0
+    for row in rows:
+        monto_raw = str(row.get("Monto IVA", "") or "").strip()
+        if not monto_raw:
+            continue
+        monto_clean = monto_raw.replace("$", "").replace(",", "")
+        try:
+            total += float(monto_clean)
+        except ValueError:
+            continue
+    return round(total, 2)
 
 
 def show_material_table(raw_text: str) -> None:
@@ -3125,6 +3149,46 @@ with tab1:
     else:
         st.session_state.pop("tipo_envio_original", None)
 
+    if tipo_envio == "🔁 Devolución":
+        st.markdown("#### 📦 Material a Devolver (captura por renglón)")
+        st.caption("Agrega una fila por producto para evitar mezclas de código, descripción, cantidad y monto.")
+        material_seed = st.session_state.get("material_devuelto", "")
+        if "material_devuelto_editor_seed" not in st.session_state:
+            st.session_state["material_devuelto_editor_seed"] = material_seed
+        if "material_devuelto_editor_rows" not in st.session_state:
+            st.session_state["material_devuelto_editor_rows"] = get_material_rows_for_editor(material_seed)
+
+        if material_seed != st.session_state.get("material_devuelto_editor_seed", "") and material_seed.strip():
+            st.session_state["material_devuelto_editor_rows"] = get_material_rows_for_editor(material_seed)
+            st.session_state["material_devuelto_editor_seed"] = material_seed
+
+        material_editor_df = st.data_editor(
+            pd.DataFrame(st.session_state.get("material_devuelto_editor_rows", [])),
+            key="material_devuelto_editor",
+            num_rows="dynamic",
+            hide_index=True,
+            use_container_width=True,
+            column_config={
+                "Código": st.column_config.TextColumn("Código", help="Ejemplo: TOR-208"),
+                "Descripción": st.column_config.TextColumn("Descripción"),
+                "Cantidad": st.column_config.NumberColumn("Cantidad", min_value=0, step=1, format="%d"),
+                "Monto IVA": st.column_config.TextColumn("Monto IVA", help="Ejemplo: 5719.96 o $5,719.96"),
+            },
+        )
+        material_rows_clean = sanitize_material_editor_rows(material_editor_df)
+        st.session_state["material_devuelto_editor_rows"] = material_rows_clean
+        st.session_state["material_devuelto"] = format_material_rows_for_storage(material_rows_clean)
+        st.session_state["monto_devuelto"] = sum_material_rows_monto_iva(material_rows_clean)
+
+        st.number_input(
+            "💲 Total de Materiales a Devolver (con IVA)",
+            min_value=0.0,
+            format="%.2f",
+            value=float(st.session_state.get("monto_devuelto", 0.0)),
+            disabled=True,
+            help="Se calcula automáticamente con la suma de la columna 'Monto IVA' en tiempo real.",
+        )
+
     subtipo_local = ""
     is_local_pasa_bodega = False
     is_local_recoge_aula = False
@@ -3683,42 +3747,8 @@ with tab1:
                 key="resultado_esperado"
             )
 
-            st.markdown("#### 📦 Material a Devolver (captura por renglón)")
-            st.caption("Agrega una fila por producto para evitar mezclas de código, descripción, cantidad y monto.")
-            material_seed = st.session_state.get("material_devuelto", "")
-            if "material_devuelto_editor_seed" not in st.session_state:
-                st.session_state["material_devuelto_editor_seed"] = material_seed
-            if "material_devuelto_editor_rows" not in st.session_state:
-                st.session_state["material_devuelto_editor_rows"] = get_material_rows_for_editor(material_seed)
-
-            if material_seed != st.session_state.get("material_devuelto_editor_seed", "") and material_seed.strip():
-                st.session_state["material_devuelto_editor_rows"] = get_material_rows_for_editor(material_seed)
-                st.session_state["material_devuelto_editor_seed"] = material_seed
-
-            material_editor_df = st.data_editor(
-                pd.DataFrame(st.session_state.get("material_devuelto_editor_rows", [])),
-                key="material_devuelto_editor",
-                num_rows="dynamic",
-                hide_index=True,
-                use_container_width=True,
-                column_config={
-                    "Código": st.column_config.TextColumn("Código", help="Ejemplo: TOR-208"),
-                    "Descripción": st.column_config.TextColumn("Descripción"),
-                    "Cantidad": st.column_config.NumberColumn("Cantidad", min_value=0, step=1, format="%d"),
-                    "Monto IVA": st.column_config.TextColumn("Monto IVA", help="Ejemplo: 5719.96 o $5,719.96"),
-                },
-            )
-            material_rows_clean = sanitize_material_editor_rows(material_editor_df)
-            st.session_state["material_devuelto_editor_rows"] = material_rows_clean
-            material_devuelto = format_material_rows_for_storage(material_rows_clean)
-            st.session_state["material_devuelto"] = material_devuelto
-
-            monto_devuelto = st.number_input(
-                "💲 Total de Materiales a Devolver (con IVA)",
-                min_value=0.0,
-                format="%.2f",
-                key="monto_devuelto"
-            )
+            material_devuelto = st.session_state.get("material_devuelto", "N/A")
+            monto_devuelto = float(st.session_state.get("monto_devuelto", 0.0) or 0.0)
 
             area_responsable = st.selectbox(
                 "🏷 Área Responsable del Error",


### PR DESCRIPTION
### Motivation
- Ensure material return rows are cleaned of literal `None`/`NaN` string inputs and provide a reliable total IVA for returns.
- Expose the material editor earlier when `tipo_envio == "🔁 Devolución"` so users can capture returned items per row and see an automatic total.

### Description
- Enhanced `sanitize_material_editor_rows` to normalize literal string values like `"NONE"`, `"NAN"`, `"none"`, and `"nan"` into empty values before further parsing.  
- Added `sum_material_rows_monto_iva(rows: List[Dict[str,str]]) -> float` to compute the total IVA from the cleaned rows while ignoring invalid or empty amounts.  
- Integrated the material return `st.data_editor` UI earlier in the shipping selector block when `tipo_envio == "🔁 Devolución"`, synchronizing `st.session_state` keys `material_devuelto_editor_rows`, `material_devuelto`, and `monto_devuelto`.  
- Replaced the prior in-place editor under the Devolución section with read-only usage of the stored values, using a disabled `st.number_input` to display the automatically calculated total IVA.

### Testing
- Ran the project's unit test suite with `pytest` and the linter `flake8`; both completed without failures.  
- Manually exercised the Devolución flow in the app to verify the editor appears in the selector block, `material_devuelto` is stored in session state, and `monto_devuelto` updates as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de5ff9af6483269ad9f79de5135673)