### PR TITLE
Normalize material editor inputs, compute Monto IVA total, and improve Devolución UI

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -341,6 +341,15 @@ def sanitize_material_editor_rows(edited_df: pd.DataFrame) -> List[Dict[str, str
         cantidad_raw = str(row.get("Cantidad", "") or "").strip()
         monto_raw = str(row.get("Monto IVA", "") or "").strip().replace("$", "").replace(",", "")
 
+        if codigo in {"NONE", "NAN"}:
+            codigo = ""
+        if descripcion.lower() in {"none", "nan"}:
+            descripcion = ""
+        if cantidad_raw.lower() in {"none", "nan"}:
+            cantidad_raw = ""
+        if monto_raw.lower() in {"none", "nan"}:
+            monto_raw = ""
+
         if not any([codigo, descripcion, cantidad_raw, monto_raw]):
             continue
 
@@ -368,6 +377,21 @@ def sanitize_material_editor_rows(edited_df: pd.DataFrame) -> List[Dict[str, str
             }
         )
     return cleaned_rows
+
+
+def sum_material_rows_monto_iva(rows: List[Dict[str, str]]) -> float:
+    """Return total IVA amount from material rows (ignoring invalid/empty values)."""
+    total = 0.0
+    for row in rows:
+        monto_raw = str(row.get("Monto IVA", "") or "").strip()
+        if not monto_raw:
+            continue
+        monto_clean = monto_raw.replace("$", "").replace(",", "")
+        try:
+            total += float(monto_clean)
+        except ValueError:
+            continue
+    return round(total, 2)
 
 
 def show_material_table(raw_text: str) -> None:
@@ -3684,7 +3708,7 @@ with tab1:
             )
 
             st.markdown("#### 📦 Material a Devolver (captura por renglón)")
-            st.caption("Agrega una fila por producto para evitar mezclas de código, descripción, cantidad y monto.")
+            st.caption("Captura tus renglones y después presiona 'Aceptar materiales' para refrescar y calcular el total.")
             material_seed = st.session_state.get("material_devuelto", "")
             if "material_devuelto_editor_seed" not in st.session_state:
                 st.session_state["material_devuelto_editor_seed"] = material_seed
@@ -3710,14 +3734,23 @@ with tab1:
             )
             material_rows_clean = sanitize_material_editor_rows(material_editor_df)
             st.session_state["material_devuelto_editor_rows"] = material_rows_clean
-            material_devuelto = format_material_rows_for_storage(material_rows_clean)
-            st.session_state["material_devuelto"] = material_devuelto
+            st.session_state["material_devuelto"] = format_material_rows_for_storage(material_rows_clean)
+            st.session_state["monto_devuelto"] = sum_material_rows_monto_iva(material_rows_clean)
 
-            monto_devuelto = st.number_input(
+            aceptar_material_button = st.form_submit_button(
+                "✅ Aceptar materiales y calcular total",
+                help="Al presionar, se actualiza el total con la suma de la columna 'Monto IVA'.",
+            )
+            if aceptar_material_button:
+                st.success("✅ Materiales aceptados. Total actualizado.")
+
+            material_devuelto = st.session_state.get("material_devuelto", "N/A")
+            monto_devuelto = float(st.session_state.get("monto_devuelto", 0.0) or 0.0)
+            st.text_input(
                 "💲 Total de Materiales a Devolver (con IVA)",
-                min_value=0.0,
-                format="%.2f",
-                key="monto_devuelto"
+                value=f"${monto_devuelto:,.2f}",
+                disabled=True,
+                help="Formato moneda: símbolo $, separador de miles y 2 decimales.",
             )
 
             area_responsable = st.selectbox(


### PR DESCRIPTION
### Motivation
- Normalize common invalid editor values like `None`/`NaN` and provide a clear computed total for returned materials to avoid incorrect storage and improve UX during the Devolución flow.
- Make the materials acceptance explicit and show a formatted, read-only total so users understand when totals are updated.

### Description
- Treat `"NONE"`, `"NAN"` (case-insensitive) in `Código`, `Descripción`, `Cantidad`, and `Monto IVA` as empty values in `sanitize_material_editor_rows` to avoid persisting placeholder tokens.
- Add `sum_material_rows_monto_iva(rows: List[Dict[str, str]]) -> float` to compute the total IVA from material rows while ignoring invalid values.
- Store computed `monto_devuelto` in `st.session_state` and add an `Aceptar materiales y calcular total` form submit button that confirms acceptance and refreshes the total.
- Update Devolución UI: change caption text, display the total as a disabled formatted `st.text_input` with currency formatting, and ensure `material_devuelto` is persisted from cleaned rows.

### Testing
- Ran the existing automated test suite with `pytest` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de5ff9af6483269ad9f79de5135673)