### PR TITLE
Ajusta el espacio entre confirmación y total en devolución de materiales

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -3789,10 +3789,12 @@ with tab1:
 
             material_devuelto = st.session_state.get("material_devuelto", "N/A")
             monto_devuelto = float(st.session_state.get("monto_devuelto", 0.0) or 0.0)
+            st.markdown("💲 **Total de Materiales a Devolver (con IVA)**")
             st.text_input(
-                "💲 Total de Materiales a Devolver (con IVA)",
+                "Total de Materiales a Devolver (con IVA)",
                 value=f"${monto_devuelto:,.2f}",
                 disabled=True,
+                label_visibility="collapsed",
                 help="Formato moneda: símbolo $, separador de miles y 2 decimales.",
             )
 


### PR DESCRIPTION
### Motivation
- Reducir el espacio visual entre el mensaje de confirmación `✅ Materiales aceptados. Total actualizado.` y el campo que muestra el total en Tab 1 (tipo de envío «Devoluciones») para mejorar la presentación del formulario.

### Description
- En `app_v.py` se movió la etiqueta del total a `st.markdown` y se dejó el `st.text_input` del total con `label_visibility="collapsed"`, sin cambiar la lógica de cálculo del monto.

### Testing
- Se ejecutó `python -m py_compile app_v.py` y la compilación del módulo terminó sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de6d6ba5c48326a1b215ee7b1ceb94)