### PR TITLE
UI: style success message and improve total display for returned materials

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -3784,15 +3784,26 @@ with tab1:
             if aceptar_material_button:
                 with st.spinner("Actualizando materiales y total..."):
                     time.sleep(0.25)
-                st.success("✅ Materiales aceptados. Total actualizado.")
+                st.markdown(
+                    """
+                    <div style="margin: 0.35rem 0 0.15rem 0; padding: 0.75rem 1rem; border-radius: 0.5rem;
+                                background: rgba(34, 197, 94, 0.22); border: 1px solid rgba(34, 197, 94, 0.38);
+                                color: var(--text-color); font-weight: 600;">
+                        ✅ Materiales aceptados. Total actualizado.
+                    </div>
+                    """,
+                    unsafe_allow_html=True,
+                )
                 scroll_to_tab1_devolucion_material_section()
 
             material_devuelto = st.session_state.get("material_devuelto", "N/A")
             monto_devuelto = float(st.session_state.get("monto_devuelto", 0.0) or 0.0)
+            st.markdown("💲 **Total de Materiales a Devolver (con IVA)**")
             st.text_input(
-                "💲 Total de Materiales a Devolver (con IVA)",
+                "Total de Materiales a Devolver (con IVA)",
                 value=f"${monto_devuelto:,.2f}",
                 disabled=True,
+                label_visibility="collapsed",
                 help="Formato moneda: símbolo $, separador de miles y 2 decimales.",
             )
 


### PR DESCRIPTION
### Motivation
- Improve user feedback and visual clarity after accepting returned materials by replacing the plain `st.success` with a styled message and ensuring the total field is more readable.
- Make the total amount label visually prominent while keeping the `st.text_input` value accessible but with collapsed native label to reduce clutter.

### Description
- Replaced the `st.success("✅ Materiales aceptados. Total actualizado.")` call with a custom HTML-styled `st.markdown(..., unsafe_allow_html=True)` block to provide a visually distinct success message.
- Added a separate `st.markdown("💲 **Total de Materiales a Devolver (con IVA)**")` heading and set the subsequent `st.text_input` label to the non-emoji version with `label_visibility="collapsed"` to keep the displayed currency input clean.
- Kept existing logic that sanitizes editor rows, stores session state, computes `monto_devuelto`, and scrolls to the section after acceptance.

### Testing
- Ran the existing automated test suite with `pytest` and all tests completed successfully.
- Performed a quick UI smoke check to confirm the styled success message renders and the total input displays correctly after accepting materials.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de6d6ba5c48326a1b215ee7b1ceb94)