### PR TITLE
Usar `st.caption` y ajustar visualización del total de materiales devueltos

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -3784,15 +3784,17 @@ with tab1:
             if aceptar_material_button:
                 with st.spinner("Actualizando materiales y total..."):
                     time.sleep(0.25)
-                st.success("✅ Materiales aceptados. Total actualizado.")
+                st.caption(":green[✅ Materiales aceptados. Total actualizado.]")
                 scroll_to_tab1_devolucion_material_section()
 
             material_devuelto = st.session_state.get("material_devuelto", "N/A")
             monto_devuelto = float(st.session_state.get("monto_devuelto", 0.0) or 0.0)
+            st.markdown("💲 **Total de Materiales a Devolver (con IVA)**")
             st.text_input(
-                "💲 Total de Materiales a Devolver (con IVA)",
+                "Total de Materiales a Devolver (con IVA)",
                 value=f"${monto_devuelto:,.2f}",
                 disabled=True,
+                label_visibility="collapsed",
                 help="Formato moneda: símbolo $, separador de miles y 2 decimales.",
             )
 


### PR DESCRIPTION
### Motivation
- Reemplazar el mensaje de confirmación invasivo por uno menos llamativo y mejorar la presentación del campo de total de materiales para evitar duplicación de etiquetas en la UI.

### Description
- Se cambió `st.success` por `st.caption` con texto en verde y se añadió un encabezado con `st.markdown` antes del `st.text_input`, además se quitó el emoji del label del `text_input` y se añadió `label_visibility="collapsed"` para que solo se muestre el encabezado.

### Testing
- Se ejecutaron las pruebas automáticas del proyecto con `pytest` y el linter (`flake8`), y ambos pasaron sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de6d6ba5c48326a1b215ee7b1ceb94)