### PR TITLE
Cambiar campo 'Día de cobro' a selector de fecha en Venta terceros (Tab 1)

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -3435,7 +3435,7 @@ with tab1:
     credito_anticipo = 0.0
     credito_plazo_meses = 0
     credito_frecuencia_pago = ""
-    credito_dia_cobro = ""
+    credito_dia_cobro = None
     credito_datos_contacto = ""
 
     # Variables Devolución
@@ -3608,10 +3608,11 @@ with tab1:
                     format="%.2f",
                     key="credito_anticipo",
                 )
-                credito_dia_cobro = st.text_input(
+                credito_dia_cobro = st.date_input(
                     "🗓 Día de cobro (opcional)",
                     key="credito_dia_cobro",
-                    placeholder="Ej. Viernes / día 15",
+                    value=None,
+                    format="DD/MM/YYYY",
                 )
                 credito_datos_contacto = st.text_area(
                     "📞 Datos de contacto (opcional)",
@@ -4412,7 +4413,9 @@ with tab1:
         credito_frecuencia_pago.strip() if isinstance(credito_frecuencia_pago, str) else ""
     )
     credito_dia_cobro = (
-        credito_dia_cobro.strip() if isinstance(credito_dia_cobro, str) else ""
+        credito_dia_cobro.strftime("%Y-%m-%d")
+        if isinstance(credito_dia_cobro, date)
+        else (credito_dia_cobro.strip() if isinstance(credito_dia_cobro, str) else "")
     )
     credito_datos_contacto = (
         credito_datos_contacto.strip() if isinstance(credito_datos_contacto, str) else ""


### PR DESCRIPTION
### Motivation
- Permitir seleccionar el día de cobro con un date picker en lugar de texto libre para mejorar la consistencia del dato y facilitar la captura en la sección Crédito de "Venta terceros".

### Description
- Inicialicé `credito_dia_cobro` como `None` para soportar el estado vacío del selector de fecha.
- Reemplacé el `st.text_input` por `st.date_input` para el campo "🗓 Día de cobro (opcional)" con `value=None` y `format="DD/MM/YYYY"`.
- Ajusté la normalización previa al envío para formatear la fecha seleccionada a `YYYY-MM-DD` cuando `credito_dia_cobro` es un `date`, manteniendo la compatibilidad con cadenas en flujos de reintento.

### Testing
- Ejecuté `python -m py_compile app_v.py` y el archivo se compiló correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfc9c519b48326971edcfe408fbf8a)