### PR TITLE
Ocultar aviso de Radar Venta Terceros cuando no hay casos

### DIFF
--- a/app_admin.py
+++ b/app_admin.py
@@ -2327,9 +2327,7 @@ with tab1:
                 )
             ].copy()
 
-            if pedidos_nota_venta_terceros.empty:
-                st.info("🧭 Radar Venta Terceros: no hay notas de venta marcadas como Venta terceros por confirmar.")
-            else:
+            if not pedidos_nota_venta_terceros.empty:
                 st.warning(
                     f"🧭 Radar Venta Terceros: hay {len(pedidos_nota_venta_terceros)} nota(s) de venta marcadas como Venta terceros."
                 )


### PR DESCRIPTION
### Motivation
- Evitar que en el tab `💳 Pendientes de Confirmar` se muestre el aviso "🧭 Radar Venta Terceros: no hay notas de venta..." cuando no existen notas de venta marcadas como Venta terceros, mostrando el radar solo si hay casos.

### Description
- Cambié la condición en `app_admin.py` para usar `if not pedidos_nota_venta_terceros.empty:` en lugar de mostrar un mensaje cuando está vacío, de modo que el bloque del radar y su tabla solo se rendericen si existen filas aplicables.

### Testing
- Ejecuté `python -m py_compile /workspace/app-ventas-td/app_admin.py` y la compilación sintáctica fue exitosa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfcc6379bc8326a37095859368509c)