### PR TITLE
Handle duplicated sheet columns and refine 'Venta Terceros' notification

### DIFF
--- a/app_admin.py
+++ b/app_admin.py
@@ -1321,6 +1321,18 @@ def cargar_pedidos_desde_google_sheet(sheet_id, worksheet_name, _nonce: int = 0)
         }
         df = df.rename(columns=alias)
 
+        if not df.empty and df.columns.duplicated().any():
+            cols_coalescidas = {}
+            for col_name in pd.unique(df.columns):
+                same_name = df.loc[:, df.columns == col_name]
+                if isinstance(same_name, pd.Series) or same_name.shape[1] == 1:
+                    cols_coalescidas[col_name] = same_name.iloc[:, 0] if hasattr(same_name, "iloc") and not isinstance(same_name, pd.Series) else same_name
+                else:
+                    cols_coalescidas[col_name] = (
+                        same_name.replace("", pd.NA).bfill(axis=1).iloc[:, 0].fillna("")
+                    )
+            df = pd.DataFrame(cols_coalescidas, index=df.index)
+
         # Asegura columnas clave
         for col in ["Folio_Factura", "ID_Pedido"]:
             if col not in df.columns:
@@ -2327,9 +2339,7 @@ with tab1:
                 )
             ].copy()
 
-            if pedidos_nota_venta_terceros.empty:
-                st.info("🧭 Radar Venta Terceros: no hay notas de venta marcadas como Venta terceros por confirmar.")
-            else:
+            if not pedidos_nota_venta_terceros.empty:
                 st.warning(
                     f"🧭 Radar Venta Terceros: hay {len(pedidos_nota_venta_terceros)} nota(s) de venta marcadas como Venta terceros."
                 )


### PR DESCRIPTION
### Motivation
- Fix inconsistent behavior when Google Sheet imports contain duplicated column names so data from duplicate columns is not lost or misaligned. 
- Improve user-facing messaging for the "Venta Terceros" radar to avoid showing an informational message when there are matching records and only surface a warning when relevant.

### Description
- In `app_admin.py` inside `cargar_pedidos_desde_google_sheet`, detect duplicated `df.columns` and coalesce columns with the same name by taking the first non-empty value across duplicates using `replace(...).bfill(axis=1).iloc[:,0].fillna("")` and rebuild the DataFrame from the coalesced columns while preserving the original index. 
- Preserve existing header normalization and renaming (`alias`) and ensure key columns `Folio_Factura` and `ID_Pedido` exist and are cleaned afterwards. 
- Adjust UI logic so the previous `st.info` for an empty `pedidos_nota_venta_terceros` branch is removed and a `st.warning` is only shown when `pedidos_nota_venta_terceros` is not empty, and the relevant subset of columns is displayed when present.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfcc6379bc8326a37095859368509c)