### PR TITLE
Reubicar pestaña '🔍 Buscar Pedido' después de '📦 Guías Cargadas'

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -2969,11 +2969,11 @@ if show_tab_ventas_reportes:
 tabs_labels.extend([
     "✏️ Modificar Pedido Existente",
     "📦 Guías Cargadas",
+    "🔍 Buscar Pedido",
     "🧾 Pedidos Pendientes de Comprobante",
     "📁 Casos Especiales",
     "⏳ Pedidos No Entregados",
     "⬇️ Descargar Datos",
-    "🔍 Buscar Pedido",
 ])
 
 # Leer índice de pestaña desde los parámetros de la URL.
@@ -3062,20 +3062,20 @@ tab_ventas_reportes = tabs[1] if show_tab_ventas_reportes else None
 tab_offset = 1 if show_tab_ventas_reportes else 0
 tab2 = tabs[1 + tab_offset]
 tab5 = tabs[2 + tab_offset]
-tab3 = tabs[3 + tab_offset]
-tab4 = tabs[4 + tab_offset]
-tab6 = tabs[5 + tab_offset]
-tab7 = tabs[6 + tab_offset]
-tab8 = tabs[7 + tab_offset]
+tab8 = tabs[3 + tab_offset]
+tab3 = tabs[4 + tab_offset]
+tab4 = tabs[5 + tab_offset]
+tab6 = tabs[6 + tab_offset]
+tab7 = tabs[7 + tab_offset]
 TAB_INDEX_TAB1 = 0
 TAB_INDEX_REPORTES = 1 if show_tab_ventas_reportes else None
 TAB_INDEX_TAB2 = 1 + tab_offset
 TAB_INDEX_TAB5 = 2 + tab_offset
-TAB_INDEX_TAB3 = 3 + tab_offset
-TAB_INDEX_TAB4 = 4 + tab_offset
-TAB_INDEX_TAB6 = 5 + tab_offset
-TAB_INDEX_TAB7 = 6 + tab_offset
-TAB_INDEX_TAB8 = 7 + tab_offset
+TAB_INDEX_TAB8 = 3 + tab_offset
+TAB_INDEX_TAB3 = 4 + tab_offset
+TAB_INDEX_TAB4 = 5 + tab_offset
+TAB_INDEX_TAB6 = 6 + tab_offset
+TAB_INDEX_TAB7 = 7 + tab_offset
 
 # --- List of Vendors (reusable and explicitly alphabetically sorted) ---
 VENDEDORES_LIST = sorted([


### PR DESCRIPTION
### Motivation
- Ajustar el orden visual de las pestañas para que `🔍 Buscar Pedido` se muestre y renderice inmediatamente después de `📦 Guías Cargadas` en la interfaz de `app_v.py`.

### Description
- Reordené la lista `tabs_labels` para mover `🔍 Buscar Pedido` justo después de `📦 Guías Cargadas` en `app_v.py`.
- Actualicé las asignaciones de variables que referencian las pestañas (`tab8`, `tab3`, `tab4`, etc.) para que apunten a los índices correctos tras el cambio de orden.
- Ajusté las constantes de índice de pestañas (`TAB_INDEX_TAB8`, `TAB_INDEX_TAB3`, `TAB_INDEX_TAB4`, etc.) para mantener la sincronización entre la UI y la lógica de la aplicación.

### Testing
- Ejecuté `python -m py_compile app_v.py` y la compilación estática de Python finalizó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dff8192ae483269f1c4e4db6cd5b50)