### PR TITLE
Filtrar entregas locales a estados pendientes

### DIFF
--- a/app_admin.py
+++ b/app_admin.py
@@ -3936,9 +3936,15 @@ with tab2:
             normalize_estado_entrega
         )
 
-        df_local_filtrado = df_local.copy()
+        estados_visibles_entrega_local = {ESTADO_ENTREGA_OPCIONES[1], ""}
+        df_local_filtrado = df_local[
+            df_local[ESTADO_ENTREGA_COL].apply(normalize_estado_entrega).isin(
+                estados_visibles_entrega_local
+            )
+        ].copy()
 
         if df_local_filtrado.empty:
+            st.caption("ℹ️ No hay pedidos locales con estado pendiente de entrega.")
             return
 
         opciones_local = {


### PR DESCRIPTION
### Motivation
- Evitar que el selector de "Entregas locales" muestre pedidos ya marcados como entregados y reducir equivocaciones al actualizar estados, mostrando solo pedidos pendientes o sin estado.

### Description
- Se modificó `render_entrega_local_panel` en `app_admin.py` para filtrar `df_local` y dejar solo filas cuyo `Estado_Entrega` normalizado sea `⏳ No Entregado` o cadena vacía.
- Se añadió la caption `ℹ️ No hay pedidos locales con estado pendiente de entrega.` cuando no quedan pedidos tras el filtro.

### Testing
- Se ejecutó `python -m py_compile app_admin.py` y la verificación de sintaxis fue exitosa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e003a1797083269a74cb42a1fa4b41)