### PR TITLE
Mejora búsqueda de clientes por nombre en Tab Buscar Pedido

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -2614,6 +2614,42 @@ def normalizar_busqueda_libre(texto: object) -> str:
     """Normaliza texto para búsquedas flexibles ignorando espacios."""
     return normalizar(str(texto or "")).replace(" ", "")
 
+
+def _tokenizar_nombre_busqueda(texto: object) -> list[str]:
+    """Convierte texto en tokens alfanuméricos normalizados para comparación flexible."""
+    texto_normalizado = normalizar(str(texto or "")).strip()
+    if not texto_normalizado:
+        return []
+    return [tok for tok in re.split(r"[^a-z0-9]+", texto_normalizado) if tok]
+
+
+def coincide_nombre_cliente_busqueda(nombre: object, keyword: object) -> bool:
+    """
+    Compara nombre de cliente con una búsqueda flexible.
+    Reglas:
+      1) Coincidencia directa por subcadena.
+      2) Coincidencia por tokens en cualquier orden (ej. "denisse ramos" vs "denisse rubi ramos").
+    """
+    nombre_normalizado = normalizar(str(nombre or "")).strip()
+    keyword_normalizado = normalizar(str(keyword or "")).strip()
+
+    if not nombre_normalizado or not keyword_normalizado:
+        return False
+
+    if keyword_normalizado in nombre_normalizado:
+        return True
+
+    tokens_keyword = _tokenizar_nombre_busqueda(keyword_normalizado)
+    tokens_nombre = _tokenizar_nombre_busqueda(nombre_normalizado)
+    if not tokens_keyword or not tokens_nombre:
+        return False
+
+    # Cada token buscado debe aparecer (exacto o parcial) en algún token del nombre.
+    for token_kw in tokens_keyword:
+        if not any(token_kw in token_nombre for token_nombre in tokens_nombre):
+            return False
+    return True
+
 @st.cache_data(ttl=300)
 def obtener_prefijo_s3(pedido_id):
     posibles_prefijos = [
@@ -9168,10 +9204,9 @@ with tab8:
                 nombre = str(row.get("Cliente", "")).strip()
                 folio = str(row.get("Folio_Factura", "")).strip()
 
-                nombre_normalizado = normalizar(nombre) if nombre else ""
                 folio_normalizado = normalizar_folio(folio)
 
-                coincide_cliente = bool(nombre) and keyword_cliente_normalizado in nombre_normalizado
+                coincide_cliente = coincide_nombre_cliente_busqueda(nombre, keyword_cliente_normalizado)
                 coincide_folio = bool(folio_normalizado) and keyword_folio_normalizado == folio_normalizado
 
                 if not coincide_cliente and not coincide_folio:
@@ -9229,10 +9264,9 @@ with tab8:
                 nombre = str(row.get("Cliente", "")).strip()
                 folio = str(row.get("Folio_Factura", "")).strip()
 
-                nombre_normalizado = normalizar(nombre) if nombre else ""
                 folio_normalizado = normalizar_folio(folio)
 
-                coincide_cliente = bool(nombre) and keyword_cliente_normalizado in nombre_normalizado
+                coincide_cliente = coincide_nombre_cliente_busqueda(nombre, keyword_cliente_normalizado)
                 coincide_folio = bool(folio_normalizado) and keyword_folio_normalizado == folio_normalizado
 
                 if not coincide_cliente and not coincide_folio:


### PR DESCRIPTION
### Motivation
- Mejorar la experiencia de búsqueda en la pestaña "🔍 Buscar Pedido" para que búsquedas por nombre recuperen registros con nombres compuestos o nombres intermedios (por ejemplo, que buscar "Denisse Ramos" encuentre "DENISSE RUBI RAMOS CAMPO").

### Description
- Se añadieron dos helpers nuevos en `app_v.py`: `_tokenizar_nombre_busqueda(...)` y `coincide_nombre_cliente_busqueda(...)` para normalizar y tokenizar nombres y comparar tokens en orden independiente.
- La función de comparación mantiene la comprobación directa por subcadena y agrega coincidencia por tokens (cada token de la búsqueda debe aparecer como subcadena dentro de algún token del nombre almacenado).
- Se reemplazó la comprobación de cliente anterior por la nueva función en ambos recorridos de búsqueda (pedidos y casos especiales) dentro de la lógica de la pestaña de búsqueda.
- Los cambios son locales a `app_v.py` y preservan la búsqueda por folio y el comportamiento existente para búsquedas por GUID/guía.

### Testing
- Se ejecutó `python -m py_compile app_v.py` y la compilación de módulo finalizó sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e10567656883269043492843838238)