### PR TITLE
UI: Estilos responsivos para título de bienvenida y título de marca

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -2417,11 +2417,40 @@ if s3_status and not s3_status.get("ok", False):
     st.stop()
 
 nombre_vendedor_activo = get_session_vendedor_name() or usuario_activo
-st.markdown(f"### 👋 Bienvenido, {nombre_vendedor_activo}")
+st.markdown(f"<h3 class='home-welcome-title'>👋 Bienvenido, {nombre_vendedor_activo}</h3>", unsafe_allow_html=True)
 
 st.markdown(
     """
     <style>
+    .home-welcome-title {
+        margin: 0.35rem 0 0.8rem 0;
+        font-size: clamp(1.1rem, 1.35vw, 1.45rem) !important;
+        line-height: 1.15;
+        font-weight: 650;
+    }
+    .ventas-brand-title {
+        display: flex;
+        align-items: center;
+        gap: 0.45rem;
+        margin: 0;
+        font-size: clamp(1.8rem, 2.25vw, 2.15rem) !important;
+        line-height: 1.02;
+        font-weight: 760;
+    }
+    .ventas-brand-title img {
+        height: 1.08em;
+        width: auto;
+        vertical-align: middle;
+    }
+    div[data-testid="stTabs"] button[data-baseweb="tab"] {
+        font-size: 0.88rem !important;
+    }
+    [data-testid="stAppViewContainer"] h2 {
+        font-size: clamp(1.45rem, 1.9vw, 1.8rem) !important;
+        line-height: 1.12 !important;
+        margin-top: 0.3rem !important;
+        margin-bottom: 0.65rem !important;
+    }
     .remote-zone-status {
         border-radius: 10px;
         padding: 10px 12px;
@@ -2504,11 +2533,11 @@ def render_brand_title(icon: str, prefix: str, fallback_suffix: str, logo_path: 
             logo_b64 = base64.b64encode(logo_file.read_bytes()).decode("utf-8")
             st.markdown(
                 f"""
-                <h1 style="display:flex;align-items:center;gap:0.45rem;margin:0;">
+                <h1 class="ventas-brand-title">
                     <span>{icon}</span>
                     <span>{prefix}</span>
                     <img src="data:image/png;base64,{logo_b64}" alt="Logo TD"
-                         style="height:1.15em;width:auto;vertical-align:middle;" />
+                         />
                 </h1>
                 """,
                 unsafe_allow_html=True,
@@ -2517,7 +2546,10 @@ def render_brand_title(icon: str, prefix: str, fallback_suffix: str, logo_path: 
         except Exception:
             pass
 
-    st.title(f"{icon} {prefix} {fallback_suffix}")
+    st.markdown(
+        f"<h1 class='ventas-brand-title'>{icon} {prefix} {fallback_suffix}</h1>",
+        unsafe_allow_html=True,
+    )
     st.caption(
         f"Tip: agrega tu logo en `{logo_path}` (PNG recomendado) para reemplazar “{fallback_suffix}”."
     )


### PR DESCRIPTION
### Motivation
- Mejorar la consistencia visual y responsiva del título de bienvenida y del título de marca para que se vean mejor en distintos anchos de pantalla. 
- El cambio también busca separar la presentación (CSS) del contenido HTML para controlar tamaños, márgenes y el logo embebido de forma centralizada.

### Description
- Reemplaza el `st.markdown` simple del saludo por un `h3` con la clase `home-welcome-title` y `unsafe_allow_html=True` para aplicar estilos personalizados. 
- Inserta un bloque de estilos CSS que define `.home-welcome-title`, `.ventas-brand-title`, reglas para el logo embebido, tamaño de pestañas y ajustes de `h2` dentro del contenedor de la app. 
- Actualiza `render_brand_title` para emitir un `h1` con la clase `ventas-brand-title` y usar el logo embebido en base64 sin estilos inline, y reemplaza el `st.title` de fallback por un `st.markdown` con la misma clase. 
- Conserva la funcionalidad previa de carga/guardado de logo y de verificación de existencia del archivo; solo cambia la presentación HTML/CSS.

### Testing
- No se añadieron ni modificaron pruebas automatizadas para este cambio.
- No se ejecutaron tests automatizados como parte de este parche.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1475bb5048326876267e606b9a420)