### PR TITLE
Improve home/title styling and brand logo rendering

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -2417,11 +2417,40 @@ if s3_status and not s3_status.get("ok", False):
     st.stop()
 
 nombre_vendedor_activo = get_session_vendedor_name() or usuario_activo
-st.markdown(f"### 👋 Bienvenido, {nombre_vendedor_activo}")
+st.markdown(f"<h3 class='home-welcome-title'>👋 Bienvenido, {nombre_vendedor_activo}</h3>", unsafe_allow_html=True)
 
 st.markdown(
     """
     <style>
+    .home-welcome-title {
+        margin: 0.35rem 0 0.8rem 0;
+        font-size: clamp(1.1rem, 1.35vw, 1.45rem) !important;
+        line-height: 1.15;
+        font-weight: 650;
+    }
+    .ventas-brand-title {
+        display: flex;
+        align-items: center;
+        gap: 0.45rem;
+        margin: 0;
+        font-size: clamp(2.05rem, 3.1vw, 2.55rem) !important;
+        line-height: 1.05;
+        font-weight: 800;
+    }
+    .ventas-brand-title img {
+        height: 1.08em;
+        width: auto;
+        vertical-align: middle;
+    }
+    div[data-testid="stTabs"] button[data-baseweb="tab"] {
+        font-size: 0.8rem !important;
+    }
+    [data-testid="stAppViewContainer"] h2 {
+        font-size: clamp(1.25rem, 1.55vw, 1.5rem) !important;
+        line-height: 1.12 !important;
+        margin-top: 0.3rem !important;
+        margin-bottom: 0.65rem !important;
+    }
     .remote-zone-status {
         border-radius: 10px;
         padding: 10px 12px;
@@ -2504,11 +2533,11 @@ def render_brand_title(icon: str, prefix: str, fallback_suffix: str, logo_path: 
             logo_b64 = base64.b64encode(logo_file.read_bytes()).decode("utf-8")
             st.markdown(
                 f"""
-                <h1 style="display:flex;align-items:center;gap:0.45rem;margin:0;">
+                <h1 class="ventas-brand-title">
                     <span>{icon}</span>
                     <span>{prefix}</span>
                     <img src="data:image/png;base64,{logo_b64}" alt="Logo TD"
-                         style="height:1.15em;width:auto;vertical-align:middle;" />
+                         />
                 </h1>
                 """,
                 unsafe_allow_html=True,
@@ -2517,7 +2546,10 @@ def render_brand_title(icon: str, prefix: str, fallback_suffix: str, logo_path: 
         except Exception:
             pass
 
-    st.title(f"{icon} {prefix} {fallback_suffix}")
+    st.markdown(
+        f"<h1 class='ventas-brand-title'>{icon} {prefix} {fallback_suffix}</h1>",
+        unsafe_allow_html=True,
+    )
     st.caption(
         f"Tip: agrega tu logo en `{logo_path}` (PNG recomendado) para reemplazar “{fallback_suffix}”."
     )


### PR DESCRIPTION
### Motivation
- Make the home welcome and brand title visually consistent and responsive across viewports. 
- Allow embedding a custom logo in the main title while keeping a readable fallback when no logo is provided. 

### Description
- Replaced the plain welcome `st.markdown` with an `h3` element using the `.home-welcome-title` class and enabled `unsafe_allow_html` for custom styling. 
- Added a CSS block with responsive rules for `.home-welcome-title`, `.ventas-brand-title`, logo sizing, tab font-size, and several input/heading styles. 
- Updated `render_brand_title` to render the title as an `h1` with the `.ventas-brand-title` class and embed a base64 logo when available, and use a classed `st.markdown` fallback when the logo file is missing. 
- Kept the existing logo uploader logic and caption path reference (`assets/td_logo.png`) unchanged. 

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1475bb5048326876267e606b9a420)