### PR TITLE
Guardar pedidos CDMX/local en hoja histórica y mejorar mensaje de error

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -5045,12 +5045,27 @@ with tab1:
                             )
                             rerun_with_pedido_loading()
                 else:
-                    worksheet = get_worksheet_operativa()
+                    guardar_en_historico = (
+                        tipo_envio_excel == "🏙️ Pedidos CDMX"
+                        or (
+                            tipo_envio == "📍 Pedido Local"
+                            and subtipo_local in {"🌆 Local CDMX", "🎓 Recoge en Aula"}
+                        )
+                    )
+
+                    worksheet = (
+                        get_worksheet_historico()
+                        if guardar_en_historico
+                        else get_worksheet_operativa()
+                    )
                     if worksheet is None:
+                        destino_hoja = (
+                            SHEET_PEDIDOS_HISTORICOS if guardar_en_historico else SHEET_PEDIDOS_OPERATIVOS
+                        )
                         set_pedido_submission_status(
                             "error",
                             "❌ Falla al subir el pedido.",
-                            "No fue posible acceder a la hoja de pedidos.",
+                            f"No fue posible acceder a la hoja de pedidos ({destino_hoja}).",
                         )
                         rerun_with_pedido_loading()
                     headers = worksheet.row_values(1)


### PR DESCRIPTION
### Motivation
- Separar pedidos de CDMX y ciertos pedidos locales en la hoja histórica en lugar de la hoja operativa para mantener la operativa más limpia.
- Hacer más claro el mensaje de error indicando a qué hoja se intentó acceder cuando falla la obtención de la hoja.

### Description
- Añadida la variable `guardar_en_historico` que marca como histórico cuando `tipo_envio_excel == "🏙️ Pedidos CDMX"` o cuando `tipo_envio == "📍 Pedido Local"` y `subtipo_local` está en `{"🌆 Local CDMX", "🎓 Recoge en Aula"}`.
- Selección de hoja basada en `guardar_en_historico`: usa `get_worksheet_historico()` si es verdadero, si no `get_worksheet_operativa()`.
- Añadida la variable `destino_hoja` y actualizado el mensaje de error para incluir `destino_hoja` cuando no se puede acceder a la hoja.
- Conservada la lógica existente de verificación/creación de encabezados y manejo de errores asociados.

### Testing
- Ejecutado el suite de pruebas automatizadas con `pytest` y el linteado con `flake8`, ambos pasaron sin errores.
- Se ejecutaron pruebas unitarias que cubren la ruta de selección de hoja y las comprobaciones de encabezado; todas las pruebas automatizadas pasaron.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e25c5cd8ac8326ad5cce1b97cb3254)