### PR TITLE
Route CDMX/Local orders to historico sheet and set Estado to 'No Aplica'

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -5015,6 +5015,14 @@ with tab1:
                 st.session_state.pop("pedido_submit_disabled_at", None)
                 rerun_with_pedido_loading()
 
+            es_envio_historico_especial = (
+                tipo_envio_excel == "🏙️ Pedidos CDMX"
+                or (
+                    tipo_envio == "📍 Pedido Local"
+                    and subtipo_local in {"🌆 Local CDMX", "🎓 Recoge en Aula"}
+                )
+            )
+
             # Acceso a la hoja
             headers = []
             try:
@@ -5045,12 +5053,19 @@ with tab1:
                             )
                             rerun_with_pedido_loading()
                 else:
-                    worksheet = get_worksheet_operativa()
+                    worksheet = (
+                        get_worksheet_historico()
+                        if es_envio_historico_especial
+                        else get_worksheet_operativa()
+                    )
                     if worksheet is None:
+                        destino_hoja = (
+                            SHEET_PEDIDOS_HISTORICOS if es_envio_historico_especial else SHEET_PEDIDOS_OPERATIVOS
+                        )
                         set_pedido_submission_status(
                             "error",
                             "❌ Falla al subir el pedido.",
-                            "No fue posible acceder a la hoja de pedidos.",
+                            f"No fue posible acceder a la hoja de pedidos ({destino_hoja}).",
                         )
                         rerun_with_pedido_loading()
                     headers = worksheet.row_values(1)
@@ -5232,7 +5247,7 @@ with tab1:
                 elif header == "Adjuntos_Surtido":
                     values.append("")
                 elif header == "Estado":
-                    values.append("🟡 Pendiente")
+                    values.append("No Aplica" if es_envio_historico_especial else "🟡 Pendiente")
                 elif header == "Estado_Pago":
                     if tipo_envio in ["🚚 Pedido Foráneo", "🏙️ Pedido CDMX", "📍 Pedido Local"] or (
                         tipo_envio == "🔁 Devolución" and normalize_tipo_envio_original(tipo_envio_original) == "📍 Pedido Local"


### PR DESCRIPTION
### Motivation
- Ensure certain CDMX and local pickup orders are recorded in the historical sheet instead of the operational sheet to match business routing rules.
- Provide clearer error messages that mention the intended destination sheet when access to the chosen worksheet fails.
- Avoid showing a pending state for historic-special uploads by setting a non-applicable `Estado` value.

### Description
- Add `es_envio_historico_especial` flag that is true when `tipo_envio_excel == "🏙️ Pedidos CDMX"` or when `tipo_envio == "📍 Pedido Local"` with `subtipo_local` in `{ "🌆 Local CDMX", "🎓 Recoge en Aula" }`.
- Select `get_worksheet_historico()` when `es_envio_historico_especial` is true, otherwise use `get_worksheet_operativa()`.
- Include the destination sheet name in the worksheet access error by computing `destino_hoja` as either `SHEET_PEDIDOS_HISTORICOS` or `SHEET_PEDIDOS_OPERATIVOS` and showing it in the error message.
- Set the `Estado` column value to `"No Aplica"` for the historic-special rows instead of the previous default `"🟡 Pendiente"`.

### Testing
- Ran the test suite with `pytest` and all tests completed successfully.
- Ran code style checks with `flake8` with no new issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e25c5cd8ac8326ad5cce1b97cb3254)