### PR TITLE
Fix order-search crash when sheet headers are duplicated

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -29,7 +29,7 @@ from http.client import InvalidURL
 from oauth2client.service_account import ServiceAccountCredentials
 from pytz import timezone
 from gspread.utils import rowcol_to_a1
-from gspread.exceptions import APIError
+from gspread.exceptions import APIError, GSpreadException
 
 
 # NEW: Import boto3 for AWS S3
@@ -9079,7 +9079,29 @@ def _leer_registros_hoja_busqueda(nombre_hoja: str, retries: int = 5, base_delay
     for attempt in range(retries):
         try:
             sheet = g_spread_client.open_by_key(GOOGLE_SHEET_ID).worksheet(nombre_hoja)
-            return sheet.get_all_records()
+            try:
+                return sheet.get_all_records()
+            except GSpreadException as e:
+                if "header row in the worksheet is not unique" not in str(e):
+                    raise
+                valores = sheet.get_all_values()
+                if not valores:
+                    return []
+                headers_raw = valores[0]
+                headers = []
+                conteo_headers = {}
+                for idx, raw_header in enumerate(headers_raw, start=1):
+                    base = str(raw_header).strip() or f"col_{idx}"
+                    repeticiones = conteo_headers.get(base, 0)
+                    conteo_headers[base] = repeticiones + 1
+                    if repeticiones:
+                        base = f"{base}_{repeticiones + 1}"
+                    headers.append(base)
+                registros = []
+                for fila in valores[1:]:
+                    fila_normalizada = list(fila) + [""] * max(0, len(headers) - len(fila))
+                    registros.append(dict(zip(headers, fila_normalizada)))
+                return registros
         except APIError as e:
             last_error = e
             status = getattr(getattr(e, "response", None), "status_code", None)

--- a/app_v.py
+++ b/app_v.py
@@ -9090,13 +9090,26 @@ def _leer_registros_hoja_busqueda(nombre_hoja: str, retries: int = 5, base_delay
                 headers_raw = valores[0]
                 headers = []
                 conteo_headers = {}
+                headers_duplicados = {}
+                primera_columna_por_header = {}
                 for idx, raw_header in enumerate(headers_raw, start=1):
                     base = str(raw_header).strip() or f"col_{idx}"
                     repeticiones = conteo_headers.get(base, 0)
                     conteo_headers[base] = repeticiones + 1
+                    primera_columna_por_header.setdefault(base, idx)
                     if repeticiones:
+                        headers_duplicados.setdefault(base, []).append(idx)
                         base = f"{base}_{repeticiones + 1}"
                     headers.append(base)
+                if headers_duplicados:
+                    detalle_duplicados = ", ".join(
+                        f"{header} (columnas {', '.join(map(str, [primera_columna_por_header[header], *indices]))})"
+                        for header, indices in headers_duplicados.items()
+                    )
+                    st.session_state.setdefault("_busqueda_headers_duplicados", {})[nombre_hoja] = detalle_duplicados
+                    print(
+                        f"[BUSQUEDA_PEDIDOS] Encabezados duplicados detectados en hoja '{nombre_hoja}': {detalle_duplicados}"
+                    )
                 registros = []
                 for fila in valores[1:]:
                     fila_normalizada = list(fila) + [""] * max(0, len(headers) - len(fila))
@@ -9253,6 +9266,15 @@ with tab8:
         resultados = []
 
         df_pedidos = cargar_pedidos_busqueda()
+        headers_duplicados_busqueda = st.session_state.get("_busqueda_headers_duplicados", {})
+        if headers_duplicados_busqueda:
+            detalle_hojas = " | ".join(
+                f"{hoja}: {detalle}" for hoja, detalle in headers_duplicados_busqueda.items()
+            )
+            st.warning(
+                "Se detectaron encabezados duplicados en Google Sheets. "
+                f"Detalles: {detalle_hojas}"
+            )
         if "Hora_Registro" in df_pedidos.columns:
             df_pedidos["Hora_Registro"] = pd.to_datetime(df_pedidos["Hora_Registro"], errors="coerce")
             df_pedidos = df_pedidos.sort_values(by="Hora_Registro", ascending=not recientes_primero)


### PR DESCRIPTION
### Motivation
- The order-search flow crashed when a Google Sheet had non-unique header names because `gspread` raises a header-duplication error. 
- This bug stops the `Buscar pedido` tab from loading orders and causes an unhandled exception. 
- Provide a resilient fallback so the app can load sheets with empty or duplicated headers without failing.

### Description
- Import `GSpreadException` and catch it around the fast path `sheet.get_all_records()` call. 
- If the exception text contains `header row in the worksheet is not unique`, fall back to `sheet.get_all_values()` and reconstruct records manually. 
- Normalize headers by turning empty headers into `col_<n>` and renaming duplicates with suffixes (`_2`, `_3`, ...), then build row dictionaries matching those headers. 
- Keep existing retry and transient-API error handling intact.

### Testing
- Ran `python -m py_compile app_v.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e26368eb3c832689f9d3880b5e73d3)