### PR TITLE
Detectar fallo al cargar códigos postales remotos y mostrar aviso en la UI

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -1629,24 +1629,27 @@ def get_worksheet_casos_especiales():
     return spreadsheet.worksheet("casos_especiales")
 
 
-@st.cache_data(ttl=300, show_spinner=False)
-def get_remote_postal_codes() -> set[str]:
-    """Obtiene los códigos postales de la hoja Zonas_Remotas como strings normalizados."""
+def get_remote_postal_codes() -> tuple[set[str], bool]:
+    """Obtiene los códigos postales de la hoja Zonas_Remotas como strings normalizados.
+
+    No se cachea para evitar guardar respuestas vacías cuando Google Sheets falla
+    temporalmente y así no marcar falsos negativos en el verificador.
+    """
     worksheet = get_worksheet_zonas_remotas(st.session_state.get("remote_zones_refresh_token"))
     if worksheet is None:
-        return set()
+        return set(), False
 
     try:
         valores = worksheet.col_values(1)[1:]  # omite encabezado
     except Exception:
-        return set()
+        return set(), False
 
     codigos: set[str] = set()
     for value in valores:
         digits = re.sub(r"\D", "", str(value or "").strip())
         if digits:
             codigos.add(digits.zfill(5) if len(digits) <= 5 else digits)
-    return codigos
+    return codigos, True
 
 
 def normalize_client_history_text(value: object) -> str:
@@ -2481,7 +2484,7 @@ st.markdown(
     unsafe_allow_html=True,
 )
 
-remote_postal_codes = get_remote_postal_codes()
+remote_postal_codes, remote_codes_loaded = get_remote_postal_codes()
 _home_col_left, home_col_validator, _home_col_right = st.columns([1, 1.2, 1])
 with home_col_validator:
     st.markdown("##### ⚡ Verificador de Zonas Remotas")
@@ -2497,7 +2500,17 @@ with home_col_validator:
     cp_digits = re.sub(r"\D", "", str(cp_input or "").strip())
     cp_normalized = cp_digits.zfill(5) if cp_digits and len(cp_digits) <= 5 else cp_digits
 
-    if cp_normalized:
+    if cp_normalized and not remote_codes_loaded:
+        st.markdown(
+            (
+                "<div class='remote-zone-status remote-zone-status--remote'>"
+                "⚠️ No se pudo verificar zonas remotas en este momento. "
+                "Reintenta o usa “Recargar Página y Conexión”."
+                "</div>"
+            ),
+            unsafe_allow_html=True,
+        )
+    elif cp_normalized:
         if cp_normalized in remote_postal_codes:
             st.markdown(
                 (


### PR DESCRIPTION
### Motivation
- Evitar falsos negativos en el verificador de zonas remotas cuando Google Sheets responde temporalmente vacío o falla. 
- Mejorar la visibilidad de errores de carga para que el usuario sepa cuándo la validación no pudo realizarse.

### Description
- Cambia la firma de `get_remote_postal_codes` para devolver `tuple[set[str], bool]` donde el booleano indica si la carga fue exitosa y elimina el decorador `@st.cache_data` para evitar cachear respuestas vacías. 
- Agrega manejo explícito de errores en `get_remote_postal_codes` retornando `(set(), False)` cuando no se puede obtener la hoja o falla la lectura de columnas. 
- Normaliza y mantiene la lógica de extracción de códigos postales, retornando `(codigos, True)` cuando la carga es correcta. 
- Actualiza la lógica de la UI para asignar `remote_postal_codes, remote_codes_loaded = get_remote_postal_codes()` y mostrar un aviso con estilo cuando `remote_codes_loaded` es `False` en lugar de mostrar resultados potencialmente erróneos.

### Testing
- No se ejecutaron pruebas automatizadas sobre este cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e658c7247c8326892541fae68d3e12)