### PR TITLE
Retry loading remote postal codes and surface load errors in UI

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -1629,24 +1629,42 @@ def get_worksheet_casos_especiales():
     return spreadsheet.worksheet("casos_especiales")
 
 
-@st.cache_data(ttl=300, show_spinner=False)
-def get_remote_postal_codes() -> set[str]:
-    """Obtiene los códigos postales de la hoja Zonas_Remotas como strings normalizados."""
-    worksheet = get_worksheet_zonas_remotas(st.session_state.get("remote_zones_refresh_token"))
-    if worksheet is None:
-        return set()
+def get_remote_postal_codes(max_attempts: int = 3) -> tuple[set[str], bool, str]:
+    """Obtiene los códigos postales de la hoja Zonas_Remotas como strings normalizados.
 
-    try:
-        valores = worksheet.col_values(1)[1:]  # omite encabezado
-    except Exception:
-        return set()
+    No se cachea para evitar guardar respuestas vacías cuando Google Sheets falla
+    temporalmente y así no marcar falsos negativos en el verificador.
+    """
+    last_error = "No se pudo leer la hoja Zonas_Remotas."
 
-    codigos: set[str] = set()
-    for value in valores:
-        digits = re.sub(r"\D", "", str(value or "").strip())
-        if digits:
-            codigos.add(digits.zfill(5) if len(digits) <= 5 else digits)
-    return codigos
+    for _ in range(max_attempts):
+        # Fuerza un intento nuevo para no quedarse con un worksheet None cacheado.
+        worksheet = get_worksheet_zonas_remotas(time.time())
+        if worksheet is None:
+            last_error = "No se pudo abrir la hoja Zonas_Remotas."
+            time.sleep(0.25)
+            continue
+
+        try:
+            valores = worksheet.col_values(1)[1:]  # omite encabezado
+        except Exception as e:
+            last_error = f"Falló la lectura de Zonas_Remotas: {e}"
+            time.sleep(0.25)
+            continue
+
+        codigos: set[str] = set()
+        for value in valores:
+            digits = re.sub(r"\D", "", str(value or "").strip())
+            if digits:
+                codigos.add(digits.zfill(5) if len(digits) <= 5 else digits)
+
+        if codigos:
+            return codigos, True, ""
+
+        last_error = "La hoja Zonas_Remotas se leyó sin códigos válidos."
+        time.sleep(0.25)
+
+    return set(), False, last_error
 
 
 def normalize_client_history_text(value: object) -> str:
@@ -2481,7 +2499,7 @@ st.markdown(
     unsafe_allow_html=True,
 )
 
-remote_postal_codes = get_remote_postal_codes()
+remote_postal_codes, remote_codes_loaded, remote_codes_error = get_remote_postal_codes()
 _home_col_left, home_col_validator, _home_col_right = st.columns([1, 1.2, 1])
 with home_col_validator:
     st.markdown("##### ⚡ Verificador de Zonas Remotas")
@@ -2497,7 +2515,19 @@ with home_col_validator:
     cp_digits = re.sub(r"\D", "", str(cp_input or "").strip())
     cp_normalized = cp_digits.zfill(5) if cp_digits and len(cp_digits) <= 5 else cp_digits
 
-    if cp_normalized:
+    if cp_normalized and not remote_codes_loaded:
+        st.markdown(
+            (
+                "<div class='remote-zone-status remote-zone-status--remote'>"
+                "⚠️ No se pudo verificar zonas remotas en este momento. "
+                "Reintenta o usa “Recargar Página y Conexión”."
+                "</div>"
+            ),
+            unsafe_allow_html=True,
+        )
+        if remote_codes_error:
+            st.caption(f"Detalle técnico: {remote_codes_error}")
+    elif cp_normalized:
         if cp_normalized in remote_postal_codes:
             st.markdown(
                 (


### PR DESCRIPTION
### Motivation
- Evitar que respuestas vacías de Google Sheets queden cacheadas y provocar falsos negativos en el verificador de zonas remotas.
- Hacer más robusta la lectura de la hoja `Zonas_Remotas` ante fallos transitorios y proporcionar información de error en la UI cuando la carga falle.

### Description
- Reemplaza `get_remote_postal_codes()` cacheada por una versión sin cacheo que devuelve `tuple[set[str], bool, str]` con los códigos, un flag de éxito y un mensaje de error, y que intenta hasta `max_attempts` reintentos leyendo la hoja cada vez.
- Fuerza relecturas del `worksheet` pasando `time.time()` al obtener el cliente y agrega pausas cortas entre intentos y manejo de excepciones para acumular un `last_error` técnico.
- Actualiza la llamada y el flujo de UI para desempaquetar `remote_postal_codes, remote_codes_loaded, remote_codes_error` y mostrar un aviso cuando no se pudieron cargar los códigos y el detalle técnico si existe.
- Conserva la lógica de normalización de códigos postales y la comprobación de pertenencia sólo cuando los códigos se cargaron correctamente.

### Testing
- Ejecuté la suite de pruebas automatizadas con `pytest`, y todas las pruebas existentes pasaron.
- Ejecuté el linter `flake8` y no se reportaron errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e658c7247c8326892541fae68d3e12)