### PR TITLE
Agregar CARITO82 y KAREN58 a la vista CDMX de vendedores

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -207,6 +207,8 @@ TAB1_LOCAL_CDMX_DISABLE_ROUTE_IDS = {
     "JUAN24",
     "RUBEN67",
     "FRANKO95",
+    "CARITO82",
+    "KAREN58",
 }
 
 BRAND_LOGO_EDITOR_USERS = {"SCHAVA"}
@@ -480,7 +482,7 @@ def get_subtipo_local_excel_value(subtipo_local: str) -> str:
     return turno_normalizado
 
 
-LOCAL_TURNO_CDMX_IDS = {"RUBEN67", "JUAN24", "FRANKO95"}
+LOCAL_TURNO_CDMX_IDS = {"RUBEN67", "JUAN24", "FRANKO95", "CARITO82", "KAREN58"}
 TAB1_DUAL_VIEW_IDS = {"ALEJANDRO38", "CECILIA94"}
 
 
@@ -5640,14 +5642,14 @@ def cargar_pedidos_combinados():
     df_all = pd.concat([df_datos, df_casos], ignore_index=True)
     return df_all
 
-# --- TAB VENTAS Y REPORTES (solo RUBEN67/JUAN24/FRANKO95) ---
+# --- TAB VENTAS Y REPORTES (solo RUBEN67/JUAN24/FRANKO95/CARITO82/KAREN58) ---
 if tab_ventas_reportes is not None:
     with tab_ventas_reportes:
         if TAB_INDEX_REPORTES is not None and default_tab == TAB_INDEX_REPORTES:
             st.session_state["current_tab_index"] = TAB_INDEX_REPORTES
 
         st.header("📊 Ventas y Reportes")
-        st.caption("Pedidos registrados por RUBEN67, JUAN24 y FRANKO95.")
+        st.caption("Pedidos registrados por RUBEN67, JUAN24, FRANKO95, CARITO82 y KAREN58.")
 
         try:
             df_ventas = cargar_pedidos_ventas_reportes()


### PR DESCRIPTION
### Motivation
- Permitir que CARITO82 y KAREN58 tengan las mismas opciones y filtros de vista CDMX que los vendedores existentes para esa vista.

### Description
- Se añadieron los IDs `CARITO82` y `KAREN58` a `LOCAL_TURNO_CDMX_IDS` y a `TAB1_LOCAL_CDMX_DISABLE_ROUTE_IDS`, y se actualizó el comentario y la leyenda de la pestaña de ventas/reportes para reflejar que ahora incluye a esos dos vendedores.

### Testing
- Se compiló el archivo con `python -m py_compile app_v.py` y la comprobación pasó sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6ab684b708326968743f4032c07ea)