### PR TITLE
Update vendor access and report visibility: remove Ruben/Franko, add Carito/Karen

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -178,9 +178,7 @@ USUARIOS_VALIDOS = [
     "JUAN24",
     "KAREN58",
     "PAULINA57",
-    "RUBEN67",
     "ROBERTO51",
-    "FRANKO95",
     "SCHAVA",
 ]
 
@@ -197,16 +195,12 @@ VENDEDOR_NOMBRE_POR_ID = {
     "JUAN24": "JUAN CASTILLEJO",
     "KAREN58": "KAREN JAQUELINE",
     "PAULINA57": "PAULINA TREJO",
-    "RUBEN67": "RUBEN",
     "ROBERTO51": "DISTRIBUCION Y UNIVERSIDADES",
-    "FRANKO95": "FRANKO",
     "SCHAVA": "SCHAVA",
 }
 
 TAB1_LOCAL_CDMX_DISABLE_ROUTE_IDS = {
     "JUAN24",
-    "RUBEN67",
-    "FRANKO95",
 }
 
 BRAND_LOGO_EDITOR_USERS = {"SCHAVA"}
@@ -480,8 +474,8 @@ def get_subtipo_local_excel_value(subtipo_local: str) -> str:
     return turno_normalizado
 
 
-LOCAL_TURNO_CDMX_IDS = {"RUBEN67", "JUAN24", "FRANKO95"}
-TAB1_DUAL_VIEW_IDS = {"ALEJANDRO38", "CECILIA94"}
+LOCAL_TURNO_CDMX_IDS = {"JUAN24"}
+TAB1_DUAL_VIEW_IDS = {"ALEJANDRO38", "CECILIA94", "CARITO82", "KAREN58"}
 
 
 def get_local_shift_options(id_vendedor: str | None = None, force_cdmx_view: bool = False) -> list[str]:
@@ -3263,9 +3257,7 @@ VENDEDORES_LIST = sorted([
     "JUAN CASTILLEJO",
     "KAREN JAQUELINE",
     "PAULINA TREJO",
-    "RUBEN",
     "ROBERTO LEGRA",
-    "FRANKO"
 ])
 
 # Initialize session state for vendor (default linked to logged-in vendor ID)
@@ -5640,14 +5632,14 @@ def cargar_pedidos_combinados():
     df_all = pd.concat([df_datos, df_casos], ignore_index=True)
     return df_all
 
-# --- TAB VENTAS Y REPORTES (solo RUBEN67/JUAN24/FRANKO95) ---
+# --- TAB VENTAS Y REPORTES (solo JUAN24/CARITO82/KAREN58) ---
 if tab_ventas_reportes is not None:
     with tab_ventas_reportes:
         if TAB_INDEX_REPORTES is not None and default_tab == TAB_INDEX_REPORTES:
             st.session_state["current_tab_index"] = TAB_INDEX_REPORTES
 
         st.header("📊 Ventas y Reportes")
-        st.caption("Pedidos registrados por RUBEN67, JUAN24 y FRANKO95.")
+        st.caption("Pedidos registrados por JUAN24, CARITO82 y KAREN58.")
 
         try:
             df_ventas = cargar_pedidos_ventas_reportes()
@@ -5853,7 +5845,6 @@ if tab_ventas_reportes is not None:
                     ("Efectivo", forma_pago_norm.eq(_norm_texto("Efectivo"))),
                     ("Link", forma_pago_norm.eq(_norm_texto("Link de Pago"))),
                     ("Deposito", forma_pago_norm.eq(_norm_texto("Depósito en Efectivo"))),
-                    ("Ruben", vendedor_norm.str.startswith(_norm_texto("RUBEN"))),
                     ("Juan", vendedor_norm.str.startswith(_norm_texto("JUAN"))),
                     ("Cursos", tipo_envio_norm.str.contains(_norm_texto("Cursos y Eventos"), na=False)),
                 ]


### PR DESCRIPTION
### Motivation

- Restrict CDMX route options and report access to the proper subset of sellers and remove deprecated vendor entries.
- Ensure the Tab 1 UI and sales/reports tab reflect current operational permissions for vendors.

### Description

- Removed `RUBEN67` and `FRANKO95` from `USUARIOS_VALIDOS`, and removed their entries from `VENDEDOR_NOMBRE_POR_ID` and `VENDEDORES_LIST`.
- Restricted `LOCAL_TURNO_CDMX_IDS` to only include `JUAN24` and expanded `TAB1_DUAL_VIEW_IDS` to include `CARITO82` and `KAREN58`.
- Updated the sales/report tab to document and filter for `JUAN24`, `CARITO82`, and `KAREN58` instead of the previous `RUBEN67`/`FRANKO95` set and removed the Ruben-specific report section.
- Adjusted UI captions and filtering to match the revised vendor permissions and lists.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6ab684b708326968743f4032c07ea)