### PR TITLE
Corregir sincronización de `🕒 HORA DE ENTREGA` al cambiar `Turno/Locales`

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -3458,12 +3458,13 @@ with tab1:
                 help="Selecciona el turno o tipo de entrega para pedidos locales."
             )
             turno_local_anterior = str(st.session_state.get("local_route_last_turno", "") or "").strip()
-            hora_manual_actual = str(st.session_state.get("local_route_hora_entrega_manual", "") or "").strip()
-            hora_input_actual = str(st.session_state.get("local_route_hora_entrega_input", "") or "").strip()
-            if subtipo_local != turno_local_anterior and not hora_manual_actual:
-                default_anterior = get_local_delivery_slot(turno_local_anterior) if turno_local_anterior else ""
-                if not hora_input_actual or hora_input_actual == default_anterior:
-                    st.session_state["local_route_hora_entrega_input"] = get_local_delivery_slot(subtipo_local)
+            if subtipo_local != turno_local_anterior:
+                # Forzamos sincronización automática al cambiar turno/local:
+                # ☀️ Local Mañana -> 10 am a 2 pm
+                # 🌙 Local Tarde  -> 3 pm a 7 pm
+                # 🌵 Saltillo     -> Saltillo
+                st.session_state["local_route_hora_entrega_input"] = get_local_delivery_slot(subtipo_local)
+                st.session_state["local_route_hora_entrega_manual"] = ""
             st.session_state["local_route_last_turno"] = subtipo_local
             is_local_pasa_bodega = subtipo_local == "📦 Pasa a Bodega"
             is_local_recoge_aula = subtipo_local == "🎓 Recoge en Aula"


### PR DESCRIPTION
### Motivation
- Al cambiar el selector `Turno/Locales` en Tab 1 los pedidos locales no reflejaban automáticamente la ventana de `🕒 HORA DE ENTREGA`, lo que provocaba que permaneciera la hora anterior cuando debía mapearse a la ventana correcta.

### Description
- Se modificó la lógica en `app_v.py` para que cuando `subtipo_local` cambie siempre se asigne `st.session_state["local_route_hora_entrega_input"] = get_local_delivery_slot(subtipo_local)`.
- Se limpió la posible entrada manual previa con `st.session_state["local_route_hora_entrega_manual"] = ""` al cambiar el turno para evitar valores obsoletos.
- La asignación respeta el mapeo existente de `get_local_delivery_slot` (por ejemplo `☀️ Local Mañana -> 10 am a 2 pm`, `🌙 Local Tarde -> 3 pm a 7 pm`, `🌵 Saltillo -> Saltillo`).

### Testing
- Se compiló el archivo modificado con `python -m py_compile app_v.py` y la compilación fue exitosa.
- No se ejecutaron pruebas automatizadas de IU en este entorno; el cambio es limitado y fue verificado por la compilación estática del módulo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e795290a448326b6baa93d4e3028df)