### PR TITLE
Add Streamlit discount calculator expander with Excel-like logic

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -2745,6 +2745,106 @@ if can_edit_brand_logo():
     render_logo_uploader("assets/td_logo.png", "ventas")
 st.write("¡Bienvenido! Aquí puedes registrar y gestionar tus pedidos.")
 
+# --- INICIO BLOQUE: Calculadora de descuento (replica lógica de Excel) ---
+DESCUENTO_TARGET_KEY = "discount_target_price"
+DESCUENTO_REGULAR_KEY = "discount_regular_prices"
+DESCUENTO_INPUT_PREFIX = "discount_regular_value_"
+
+if DESCUENTO_TARGET_KEY not in st.session_state:
+    st.session_state[DESCUENTO_TARGET_KEY] = 0.0
+if DESCUENTO_REGULAR_KEY not in st.session_state:
+    st.session_state[DESCUENTO_REGULAR_KEY] = [0.0]
+
+
+def clear_discount_calculator_state() -> None:
+    """Limpia todos los valores del bloque sin chocar con llaves de widgets activas."""
+    st.session_state[DESCUENTO_TARGET_KEY] = 0.0
+    for key in list(st.session_state.keys()):
+        if key.startswith(DESCUENTO_INPUT_PREFIX):
+            st.session_state.pop(key, None)
+    st.session_state[DESCUENTO_REGULAR_KEY] = [0.0]
+
+
+with st.expander("🧮 Calculadora de descuento", expanded=False):
+    top_col_1, top_col_2, top_col_3 = st.columns([2.2, 1, 1])
+    with top_col_1:
+        st.number_input(
+            "Precio a obtener",
+            min_value=0.0,
+            step=0.01,
+            format="%.2f",
+            key=DESCUENTO_TARGET_KEY,
+        )
+    with top_col_2:
+        st.write("")
+        st.button("➕ Agregar", key="discount_add_regular")
+    with top_col_3:
+        st.write("")
+        st.button(
+            "🧹 Limpiar",
+            key="discount_clear_all",
+            on_click=clear_discount_calculator_state,
+        )
+
+    precios_regulares = st.session_state[DESCUENTO_REGULAR_KEY]
+    if st.session_state.get("discount_add_regular"):
+        precios_regulares.append(0.0)
+        st.session_state[DESCUENTO_REGULAR_KEY] = precios_regulares
+        st.rerun()
+
+    st.markdown("**Precios regulares**")
+    precios_capturados: list[float] = []
+    for idx, valor_inicial in enumerate(precios_regulares):
+        col_input, col_delete = st.columns([5, 1])
+        with col_input:
+            valor_actual = st.number_input(
+                f"Precio regular {idx + 1}",
+                min_value=0.0,
+                step=0.01,
+                format="%.2f",
+                value=float(valor_inicial),
+                key=f"{DESCUENTO_INPUT_PREFIX}{idx}",
+                label_visibility="collapsed",
+                placeholder=f"Precio regular {idx + 1}",
+            )
+            precios_regulares[idx] = valor_actual
+            if valor_actual > 0:
+                precios_capturados.append(valor_actual)
+        with col_delete:
+            st.write(" ")
+            if len(precios_regulares) > 1 and st.button(
+                "🗑️", key=f"discount_remove_regular_{idx}", help="Quitar precio"
+            ):
+                precios_regulares.pop(idx)
+                st.session_state[DESCUENTO_REGULAR_KEY] = precios_regulares
+                st.session_state.pop(f"{DESCUENTO_INPUT_PREFIX}{idx}", None)
+                st.rerun()
+
+    st.session_state[DESCUENTO_REGULAR_KEY] = precios_regulares
+
+    # Cálculo de suma de precios regulares válidos (>0).
+    suma_precios_regulares = float(sum(precios_capturados))
+    precio_objetivo = float(st.session_state[DESCUENTO_TARGET_KEY] or 0.0)
+
+    st.caption(f"Suma precio regular: {suma_precios_regulares:.2f}")
+
+    if precio_objetivo <= 0:
+        st.warning("Ingresa un 'Precio a obtener' válido (numérico y mayor a 0).")
+    elif not precios_capturados or suma_precios_regulares <= 0:
+        st.warning("Agrega al menos un 'Precio regular' válido (numérico y mayor a 0).")
+    else:
+        # Cálculo de descuento exacto: ABS((Precio_A_Obtener / SUMA_Precio_Regular) - 1)
+        descuento_factor = abs((precio_objetivo / suma_precios_regulares) - 1)
+        descuento_porcentaje = descuento_factor * 100
+        st.metric("Descuento a aplicar", f"{descuento_porcentaje:.2f}%")
+        st.caption(f"Factor decimal: {descuento_factor:.4f}")
+
+    st.caption(
+        "Precios capturados: "
+        + (", ".join(f"{p:.2f}" for p in precios_capturados) if precios_capturados else "Sin datos válidos")
+    )
+# --- FIN BLOQUE: Calculadora de descuento ---
+
 id_vendedor_sesion_global = normalize_vendedor_id(st.session_state.get("id_vendedor", ""))
 if id_vendedor_sesion_global:
     pendientes_devoluciones_home = obtener_devoluciones_autorizadas_sin_folio(id_vendedor_sesion_global)


### PR DESCRIPTION
### Motivation
- Provide an interactive tool to compute the discount required to reach a target price from a set of regular prices using the same logic as an Excel formula.
- Keep the feature self-contained and stateful within the Streamlit session so users can add/remove prices and clear inputs without interfering with other widgets.

### Description
- Introduces a new collapsible block `🧮 Calculadora de descuento` in `app_v.py` that is controlled by session keys `discount_target_price`, `discount_regular_prices`, and input keys prefixed with `discount_regular_value_`.
- Adds UI controls to set the `Precio a obtener`, add/remove regular prices, and clear all values via `clear_discount_calculator_state`, with buttons triggering `st.rerun()` where needed to update the UI.
- Computes the discount as `abs((Precio_A_Obtener / sum(Precios_regulares)) - 1)` and displays the result with `st.metric` and captions showing the decimal factor and captured prices.
- Manages session persistence for the dynamic list of regular prices and avoids key collisions by using a consistent prefix for generated inputs.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7ab3f029c8326b9cc30d2357d39e0)