### PR TITLE
Desactivar generación de hoja de ruta para turnos 'Pasa a Bodega' y 'Recoge en Aula'

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -3835,27 +3835,30 @@ with tab1:
             subtipo_local = "☀️ Local Mañana"
             st.session_state["subtipo_local_selector"] = subtipo_local
 
-        if is_local_recoge_aula:
+        if is_local_recoge_aula or is_local_pasa_bodega:
             usa_hoja_ruta_local = False
 
         if not usa_hoja_ruta_local:
             st.session_state["local_route_selected_history_label"] = None
             st.session_state["local_route_selected_history_row"] = None
-            if is_local_recoge_aula:
+            if is_local_recoge_aula or is_local_pasa_bodega:
                 st.session_state["local_route_hora_entrega_manual"] = ""
                 st.session_state["local_route_dia_entrega"] = ""
                 st.session_state.pop("local_route_hora_entrega_input", None)
                 st.session_state.pop("local_route_hora_entrega_selector", None)
                 st.session_state.pop("local_route_hora_entrega_custom", None)
+            if is_local_recoge_aula and is_local_pasa_bodega:
+                st.caption(
+                    "ℹ️ Para **📦 Pasa a Bodega** y **🎓 Recoge en Aula** no se usa hoja de ruta ni actualización de `Clientes_Locales`."
+                )
+            elif is_local_recoge_aula:
                 st.caption(
                     "ℹ️ Para **🎓 Recoge en Aula** no se usa hoja de ruta ni actualización de `Clientes_Locales`."
                 )
-        elif is_local_pasa_bodega:
-            st.session_state["local_route_selected_history_label"] = None
-            st.session_state["local_route_selected_history_row"] = None
-            st.caption(
-                "ℹ️ Para **📦 Pasa a Bodega** no se usa búsqueda automática de cliente ni actualización de `Clientes_Locales`."
-            )
+            elif is_local_pasa_bodega:
+                st.caption(
+                    "ℹ️ Para **📦 Pasa a Bodega** no se usa hoja de ruta ni actualización de `Clientes_Locales`."
+                )
         else:
             pending_registro_cliente = st.session_state.pop("local_route_pending_registro_cliente", None)
             if pending_registro_cliente is not None:


### PR DESCRIPTION
### Motivation
- Evitar que la app intente generar la hoja de ruta y actualizar `Clientes_Locales` cuando el pedido local se marca con turno **📦 Pasa a Bodega** o **🎓 Recoge en Aula** para reflejar el comportamiento esperado en esos flujos.

### Description
- Se actualizó la lógica en `app_v.py` para forzar `usa_hoja_ruta_local = False` cuando `is_local_pasa_bodega` o `is_local_recoge_aula` son verdaderos.
- Se limpian las claves de sesión relacionadas con hoja de ruta (`local_route_hora_entrega_manual`, `local_route_dia_entrega`, `local_route_hora_entrega_input`, `local_route_hora_entrega_selector`, `local_route_hora_entrega_custom`) para evitar arrastres de datos entre capturas.
- Se unificaron y ajustaron los mensajes informativos (`st.caption`) para aclarar que en esos turnos no se usa hoja de ruta ni se actualiza `Clientes_Locales`.
- Cambios realizados en `app_v.py` alrededor del bloque de selección de `subtipo_local`/turno (Tab 1 local handling).

### Testing
- Se ejecutó la compilación de sintaxis con `python -m py_compile app_v.py` y finalizó con éxito.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8e6481ac48326a6a7fdfcfea1dfd8)