### PR TITLE
Incluir `datos_pedidos` y columna alterna de guía al consolidar guías

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -1062,11 +1062,16 @@ def obtener_resumen_guias_vendedor(id_vendedor_norm: str, refresh_token: float |
     if not id_vendedor_norm:
         return {"total": 0, "clientes": [], "keys": []}
 
-    try:
-        ws_ped = get_worksheet_operativa(refresh_token)
-        df_ped = pd.DataFrame(ws_ped.get_all_records())
-    except Exception:
-        df_ped = pd.DataFrame()
+    def _load_pedidos_sheet(ws_getter) -> pd.DataFrame:
+        try:
+            ws = ws_getter(refresh_token)
+            return pd.DataFrame(ws.get_all_records()) if ws is not None else pd.DataFrame()
+        except Exception:
+            return pd.DataFrame()
+
+    df_ped_operativa = _load_pedidos_sheet(get_worksheet_operativa)
+    df_ped_historica = _load_pedidos_sheet(get_worksheet_historico)
+    df_ped = pd.concat([df_ped_operativa, df_ped_historica], ignore_index=True)
 
     try:
         ws_casos = get_worksheet_casos_especiales()
@@ -1074,7 +1079,7 @@ def obtener_resumen_guias_vendedor(id_vendedor_norm: str, refresh_token: float |
     except Exception:
         df_casos = pd.DataFrame()
 
-    for col in ["id_vendedor", "Adjuntos_Guia", "Cliente", "ID_Pedido", "Folio_Factura", "Completados_Limpiado"]:
+    for col in ["id_vendedor", "Adjuntos_Guia", "Hoja_Ruta_Mensajero", "Cliente", "ID_Pedido", "Folio_Factura", "Completados_Limpiado"]:
         if col not in df_ped.columns:
             df_ped[col] = ""
 
@@ -1082,9 +1087,14 @@ def obtener_resumen_guias_vendedor(id_vendedor_norm: str, refresh_token: float |
         if col not in df_casos.columns:
             df_casos[col] = ""
 
+    df_ped = df_ped.copy()
+    ped_guides_col = df_ped["Adjuntos_Guia"].astype(str).str.strip()
+    ped_guide_fallback = df_ped["Hoja_Ruta_Mensajero"].astype(str).str.strip()
+    df_ped["Guia_Consolidada"] = ped_guides_col.mask(ped_guides_col.eq(""), ped_guide_fallback)
+
     df_ped = df_ped[
         (df_ped["id_vendedor"].apply(normalize_vendedor_id) == id_vendedor_norm)
-        & (df_ped["Adjuntos_Guia"].astype(str).str.strip() != "")
+        & (df_ped["Guia_Consolidada"].astype(str).str.strip() != "")
         & (df_ped["Completados_Limpiado"].fillna("").astype(str).str.strip() == "")
     ].copy()
 
@@ -1102,9 +1112,9 @@ def obtener_resumen_guias_vendedor(id_vendedor_norm: str, refresh_token: float |
         if cliente:
             clientes.append(cliente)
         pedido_ref = str(row.get("ID_Pedido", "")).strip() or str(row.get("Folio_Factura", "")).strip()
-        guia_ref = str(row.get("Adjuntos_Guia", "")).strip()
+        guia_ref = str(row.get("Guia_Consolidada", "")).strip()
         if pedido_ref and guia_ref:
-            keys.append(f"{SHEET_PEDIDOS_OPERATIVOS}::{pedido_ref}::{guia_ref}")
+            keys.append(f"pedidos::{pedido_ref}::{guia_ref}")
 
     for _, row in df_casos.iterrows():
         cliente = str(row.get("Cliente", "")).strip()
@@ -8419,14 +8429,20 @@ def cargar_datos_guias_unificadas(refresh_token: float | None = None):
             return pd.DataFrame()
 
         for col in ["ID_Pedido","Cliente","Vendedor_Registro","Tipo_Envio","Estado",
-                    "Fecha_Entrega","Hora_Registro","Folio_Factura","Adjuntos_Guia","id_vendedor","Completados_Limpiado"]:
+                    "Fecha_Entrega","Hora_Registro","Folio_Factura","Adjuntos_Guia","Hoja_Ruta_Mensajero","id_vendedor","Completados_Limpiado"]:
             if col not in df_ped.columns:
                 df_ped[col] = ""
 
-        df_res = df_ped[df_ped["Adjuntos_Guia"].astype(str).str.strip() != ""].copy()
+        df_work = df_ped.copy()
+        guides_primary = df_work["Adjuntos_Guia"].astype(str).str.strip()
+        guides_fallback = df_work["Hoja_Ruta_Mensajero"].astype(str).str.strip()
+        df_work["Adjuntos_Guia_Consolidado"] = guides_primary.mask(guides_primary.eq(""), guides_fallback)
+
+        df_res = df_work[df_work["Adjuntos_Guia_Consolidado"].astype(str).str.strip() != ""].copy()
         if df_res.empty:
             return df_res
 
+        df_res["Adjuntos_Guia"] = df_res["Adjuntos_Guia_Consolidado"].astype(str)
         df_res["Fuente"] = fuente
         df_res["URLs_Guia"] = df_res["Adjuntos_Guia"].astype(str)
         df_res["Ultima_Guia"] = df_res["URLs_Guia"].apply(


### PR DESCRIPTION
### Motivation

- Corrige que algunas guías no aparecían en la vista/alertas porque el resumen solo leía `data_pedidos` y no consideraba el histórico `datos_pedidos` ni la columna alternativa de guía.

### Description

- En `app_v.py` se añade un helper `_load_pedidos_sheet` y `obtener_resumen_guias_vendedor` ahora concatena registros de `data_pedidos` y `datos_pedidos` antes de calcular resumen y alertas. 
- Se introduce `Guia_Consolidada` para pedidos y se consolida `Adjuntos_Guia` con `Hoja_Ruta_Mensajero` como fallback para no omitir guías que estén en la columna alterna. 
- En `cargar_datos_guias_unificadas` la normalización de pedidos ahora crea `Adjuntos_Guia_Consolidado` y sustituye `Adjuntos_Guia` por el valor consolidado para que la unificación de Tab 5 incluya registros históricos y con columnas alternativas. 
- Al generar las keys para el resumen se usa un prefijo uniforme para pedidos y se preserva la lógica existente para `casos_especiales`.

### Testing

- Se ejecutó `python -m py_compile app_v.py` y la compilación fue exitosa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f3651e4c8326bc15a52e20320bec)