### PR TITLE
Consolidate guide fields and include historic orders in guia summaries

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -1062,11 +1062,16 @@ def obtener_resumen_guias_vendedor(id_vendedor_norm: str, refresh_token: float |
     if not id_vendedor_norm:
         return {"total": 0, "clientes": [], "keys": []}
 
-    try:
-        ws_ped = get_worksheet_operativa(refresh_token)
-        df_ped = pd.DataFrame(ws_ped.get_all_records())
-    except Exception:
-        df_ped = pd.DataFrame()
+    def _load_pedidos_sheet(ws_getter) -> pd.DataFrame:
+        try:
+            ws = ws_getter(refresh_token)
+            return pd.DataFrame(ws.get_all_records()) if ws is not None else pd.DataFrame()
+        except Exception:
+            return pd.DataFrame()
+
+    df_ped_operativa = _load_pedidos_sheet(get_worksheet_operativa)
+    df_ped_historica = _load_pedidos_sheet(get_worksheet_historico)
+    df_ped = pd.concat([df_ped_operativa, df_ped_historica], ignore_index=True)
 
     try:
         ws_casos = get_worksheet_casos_especiales()
@@ -1074,7 +1079,7 @@ def obtener_resumen_guias_vendedor(id_vendedor_norm: str, refresh_token: float |
     except Exception:
         df_casos = pd.DataFrame()
 
-    for col in ["id_vendedor", "Adjuntos_Guia", "Cliente", "ID_Pedido", "Folio_Factura", "Completados_Limpiado"]:
+    for col in ["id_vendedor", "Adjuntos_Guia", "Hoja_Ruta_Mensajero", "Cliente", "ID_Pedido", "Folio_Factura", "Completados_Limpiado"]:
         if col not in df_ped.columns:
             df_ped[col] = ""
 
@@ -1082,9 +1087,14 @@ def obtener_resumen_guias_vendedor(id_vendedor_norm: str, refresh_token: float |
         if col not in df_casos.columns:
             df_casos[col] = ""
 
+    df_ped = df_ped.copy()
+    ped_guides_col = df_ped["Adjuntos_Guia"].astype(str).str.strip()
+    ped_guide_fallback = df_ped["Hoja_Ruta_Mensajero"].astype(str).str.strip()
+    df_ped["Guia_Consolidada"] = ped_guides_col.mask(ped_guides_col.eq(""), ped_guide_fallback)
+
     df_ped = df_ped[
         (df_ped["id_vendedor"].apply(normalize_vendedor_id) == id_vendedor_norm)
-        & (df_ped["Adjuntos_Guia"].astype(str).str.strip() != "")
+        & (df_ped["Guia_Consolidada"].astype(str).str.strip() != "")
         & (df_ped["Completados_Limpiado"].fillna("").astype(str).str.strip() == "")
     ].copy()
 
@@ -1102,9 +1112,9 @@ def obtener_resumen_guias_vendedor(id_vendedor_norm: str, refresh_token: float |
         if cliente:
             clientes.append(cliente)
         pedido_ref = str(row.get("ID_Pedido", "")).strip() or str(row.get("Folio_Factura", "")).strip()
-        guia_ref = str(row.get("Adjuntos_Guia", "")).strip()
+        guia_ref = str(row.get("Guia_Consolidada", "")).strip()
         if pedido_ref and guia_ref:
-            keys.append(f"{SHEET_PEDIDOS_OPERATIVOS}::{pedido_ref}::{guia_ref}")
+            keys.append(f"pedidos::{pedido_ref}::{guia_ref}")
 
     for _, row in df_casos.iterrows():
         cliente = str(row.get("Cliente", "")).strip()
@@ -8419,14 +8429,21 @@ def cargar_datos_guias_unificadas(refresh_token: float | None = None):
             return pd.DataFrame()
 
         for col in ["ID_Pedido","Cliente","Vendedor_Registro","Tipo_Envio","Estado",
-                    "Fecha_Entrega","Hora_Registro","Folio_Factura","Adjuntos_Guia","id_vendedor","Completados_Limpiado"]:
+                    "Fecha_Entrega","Hora_Registro","Folio_Factura","id_vendedor","Completados_Limpiado",
+                    "Adjuntos_Guia", "Hoja_Ruta_Mensajero"]:
             if col not in df_ped.columns:
                 df_ped[col] = ""
 
-        df_res = df_ped[df_ped["Adjuntos_Guia"].astype(str).str.strip() != ""].copy()
+        df_work = df_ped.copy()
+        guides_primary = df_work["Adjuntos_Guia"].astype(str).str.strip()
+        guides_fallback = df_work["Hoja_Ruta_Mensajero"].astype(str).str.strip()
+        df_work["Adjuntos_Guia_Consolidado"] = guides_primary.mask(guides_primary.eq(""), guides_fallback)
+
+        df_res = df_work[df_work["Adjuntos_Guia_Consolidado"].astype(str).str.strip() != ""].copy()
         if df_res.empty:
             return df_res
 
+        df_res["Adjuntos_Guia"] = df_res["Adjuntos_Guia_Consolidado"].astype(str)
         df_res["Fuente"] = fuente
         df_res["URLs_Guia"] = df_res["Adjuntos_Guia"].astype(str)
         df_res["Ultima_Guia"] = df_res["URLs_Guia"].apply(


### PR DESCRIPTION
### Motivation
- Some guide URLs were stored in either `Adjuntos_Guia` or `Hoja_Ruta_Mensajero`, causing missed guides when one field was empty. 
- The resumen of guías should include both operative and historic orders to provide a complete header summary. 
- Loading worksheets could raise when a sheet is missing, so fetching should be more defensive.

### Description
- Added a helper `_load_pedidos_sheet` and now concatenate operative and historic sheets in `obtener_resumen_guias_vendedor`. 
- Introduced consolidated guide columns (`Guia_Consolidada` in `obtener_resumen_guias_vendedor` and `Adjuntos_Guia_Consolidado` in `cargar_datos_guias_unificadas`) that use `Adjuntos_Guia` with fallback to `Hoja_Ruta_Mensajero`. 
- Filter and build keys using the consolidated guide field and changed pedidos key format to the `pedidos::<pedido>::<guia>` prefix. 
- Added defensive handling for possibly-missing worksheets and ensured required columns exist before access.

### Testing
- Ran the automated test suite with `pytest -q` and all tests completed successfully. 
- Ran linting via pre-commit/`flake8` and no new style issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f3651e4c8326bc15a52e20320bec)