### PR TITLE
Robust Google Sheets loading and consolidate guide fields

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -1055,6 +1055,46 @@ def schedule_pending_submission_retry(cache_key: str, delay_seconds: int = PENDI
     )
 
 
+def worksheet_to_dataframe_safe(worksheet) -> pd.DataFrame:
+    """Convierte una hoja de Google Sheets a DataFrame manejando encabezados duplicados."""
+    if worksheet is None:
+        return pd.DataFrame()
+
+    try:
+        return pd.DataFrame(worksheet.get_all_records())
+    except GSpreadException as e:
+        if "header row in the worksheet is not unique" not in str(e):
+            return pd.DataFrame()
+    except Exception:
+        return pd.DataFrame()
+
+    try:
+        values = worksheet.get_all_values()
+    except Exception:
+        return pd.DataFrame()
+    if not values:
+        return pd.DataFrame()
+
+    headers_raw = [str(h).strip() for h in values[0]]
+    headers: list[str] = []
+    seen: dict[str, int] = {}
+    for idx, header in enumerate(headers_raw, start=1):
+        base = header or f"col_{idx}"
+        count = seen.get(base, 0)
+        seen[base] = count + 1
+        headers.append(base if count == 0 else f"{base}_{count + 1}")
+
+    records: list[dict[str, str]] = []
+    max_columns = len(headers)
+    for row_values in values[1:]:
+        row = list(row_values[:max_columns])
+        if len(row) < max_columns:
+            row.extend([""] * (max_columns - len(row)))
+        records.append({headers[i]: row[i] for i in range(max_columns)})
+
+    return pd.DataFrame(records)
+
+
 @st.cache_data(ttl=60)
 def obtener_resumen_guias_vendedor(id_vendedor_norm: str, refresh_token: float | None = None) -> dict:
     """Obtiene resumen de guías cargadas para mostrar aviso rápido en encabezado."""
@@ -1062,11 +1102,16 @@ def obtener_resumen_guias_vendedor(id_vendedor_norm: str, refresh_token: float |
     if not id_vendedor_norm:
         return {"total": 0, "clientes": [], "keys": []}
 
-    try:
-        ws_ped = get_worksheet_operativa(refresh_token)
-        df_ped = pd.DataFrame(ws_ped.get_all_records())
-    except Exception:
-        df_ped = pd.DataFrame()
+    def _load_pedidos_sheet(ws_getter) -> pd.DataFrame:
+        try:
+            ws = ws_getter(refresh_token)
+            return worksheet_to_dataframe_safe(ws)
+        except Exception:
+            return pd.DataFrame()
+
+    df_ped_operativa = _load_pedidos_sheet(get_worksheet_operativa)
+    df_ped_historica = _load_pedidos_sheet(get_worksheet_historico)
+    df_ped = pd.concat([df_ped_operativa, df_ped_historica], ignore_index=True)
 
     try:
         ws_casos = get_worksheet_casos_especiales()
@@ -1074,7 +1119,7 @@ def obtener_resumen_guias_vendedor(id_vendedor_norm: str, refresh_token: float |
     except Exception:
         df_casos = pd.DataFrame()
 
-    for col in ["id_vendedor", "Adjuntos_Guia", "Cliente", "ID_Pedido", "Folio_Factura", "Completados_Limpiado"]:
+    for col in ["id_vendedor", "Adjuntos_Guia", "Hoja_Ruta_Mensajero", "Cliente", "ID_Pedido", "Folio_Factura", "Completados_Limpiado"]:
         if col not in df_ped.columns:
             df_ped[col] = ""
 
@@ -1082,9 +1127,14 @@ def obtener_resumen_guias_vendedor(id_vendedor_norm: str, refresh_token: float |
         if col not in df_casos.columns:
             df_casos[col] = ""
 
+    df_ped = df_ped.copy()
+    ped_guides_col = df_ped["Adjuntos_Guia"].astype(str).str.strip()
+    ped_guide_fallback = df_ped["Hoja_Ruta_Mensajero"].astype(str).str.strip()
+    df_ped["Guia_Consolidada"] = ped_guides_col.mask(ped_guides_col.eq(""), ped_guide_fallback)
+
     df_ped = df_ped[
         (df_ped["id_vendedor"].apply(normalize_vendedor_id) == id_vendedor_norm)
-        & (df_ped["Adjuntos_Guia"].astype(str).str.strip() != "")
+        & (df_ped["Guia_Consolidada"].astype(str).str.strip() != "")
         & (df_ped["Completados_Limpiado"].fillna("").astype(str).str.strip() == "")
     ].copy()
 
@@ -1102,9 +1152,9 @@ def obtener_resumen_guias_vendedor(id_vendedor_norm: str, refresh_token: float |
         if cliente:
             clientes.append(cliente)
         pedido_ref = str(row.get("ID_Pedido", "")).strip() or str(row.get("Folio_Factura", "")).strip()
-        guia_ref = str(row.get("Adjuntos_Guia", "")).strip()
+        guia_ref = str(row.get("Guia_Consolidada", "")).strip()
         if pedido_ref and guia_ref:
-            keys.append(f"{SHEET_PEDIDOS_OPERATIVOS}::{pedido_ref}::{guia_ref}")
+            keys.append(f"pedidos::{pedido_ref}::{guia_ref}")
 
     for _, row in df_casos.iterrows():
         cliente = str(row.get("Cliente", "")).strip()
@@ -8419,14 +8469,21 @@ def cargar_datos_guias_unificadas(refresh_token: float | None = None):
             return pd.DataFrame()
 
         for col in ["ID_Pedido","Cliente","Vendedor_Registro","Tipo_Envio","Estado",
-                    "Fecha_Entrega","Hora_Registro","Folio_Factura","Adjuntos_Guia","id_vendedor","Completados_Limpiado"]:
+                    "Fecha_Entrega","Hora_Registro","Folio_Factura","id_vendedor","Completados_Limpiado",
+                    "Adjuntos_Guia", "Hoja_Ruta_Mensajero"]:
             if col not in df_ped.columns:
                 df_ped[col] = ""
 
-        df_res = df_ped[df_ped["Adjuntos_Guia"].astype(str).str.strip() != ""].copy()
+        df_work = df_ped.copy()
+        guides_primary = df_work["Adjuntos_Guia"].astype(str).str.strip()
+        guides_fallback = df_work["Hoja_Ruta_Mensajero"].astype(str).str.strip()
+        df_work["Adjuntos_Guia_Consolidado"] = guides_primary.mask(guides_primary.eq(""), guides_fallback)
+
+        df_res = df_work[df_work["Adjuntos_Guia_Consolidado"].astype(str).str.strip() != ""].copy()
         if df_res.empty:
             return df_res
 
+        df_res["Adjuntos_Guia"] = df_res["Adjuntos_Guia_Consolidado"].astype(str)
         df_res["Fuente"] = fuente
         df_res["URLs_Guia"] = df_res["Adjuntos_Guia"].astype(str)
         df_res["Ultima_Guia"] = df_res["URLs_Guia"].apply(
@@ -8437,14 +8494,14 @@ def cargar_datos_guias_unificadas(refresh_token: float | None = None):
     # datos_pedidos (histórico)
     try:
         ws_ped_hist = get_worksheet_historico(refresh_token)
-        df_ped_hist = pd.DataFrame(ws_ped_hist.get_all_records())
+        df_ped_hist = worksheet_to_dataframe_safe(ws_ped_hist)
     except Exception:
         df_ped_hist = pd.DataFrame()
 
     # data_pedidos (operativa)
     try:
         ws_ped_op = get_worksheet_operativa(refresh_token)
-        df_ped_op = pd.DataFrame(ws_ped_op.get_all_records())
+        df_ped_op = worksheet_to_dataframe_safe(ws_ped_op)
     except Exception:
         df_ped_op = pd.DataFrame()
 


### PR DESCRIPTION
### Motivation
- Avoid crashes when Google Sheets worksheets have duplicate or missing headers by providing a resilient loader for sheet data.
- Treat guide references consistently when they can come from either `Adjuntos_Guia` or `Hoja_Ruta_Mensajero` so records are not missed.
- Normalize key naming for pedidos to a stable prefix for downstream deduplication and routing.

### Description
- Added `worksheet_to_dataframe_safe(worksheet)` which safely converts a worksheet to a `pandas.DataFrame`, handling duplicate header names, missing worksheets, and other gspread exceptions. 
- Replaced direct `pd.DataFrame(ws.get_all_records())` usages with the safe loader in `obtener_resumen_guias_vendedor` and `cargar_datos_guias_unificadas` and added a small helper `_load_pedidos_sheet` to centralize loading logic. 
- Consolidated guide fields by creating `Guia_Consolidada` or `Adjuntos_Guia_Consolidado` from `Adjuntos_Guia` with fallback to `Hoja_Ruta_Mensajero`, and updated filtering and key construction to use the consolidated value. 
- Changed pedido key prefix from `SHEET_PEDIDOS_OPERATIVOS` to `pedidos::` and ensured required columns exist before processing. 

### Testing
- Ran the test suite with `pytest` which executed sheet-loading and data-normalization unit tests and they passed. 
- Performed the cached function checks for `@st.cache_data` decorated functions to ensure they still return expected `DataFrame` shapes, and these checks passed. 
- Verified that combined loading of historical and operativa sheets produces a concatenated `DataFrame` without exceptions under duplicated-header scenarios, and automated checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f3651e4c8326bc15a52e20320bec)