### PR TITLE
Agregar filtros y resaltado de clientes con crédito en exportación de Confirmados

### DIFF
--- a/app_admin.py
+++ b/app_admin.py
@@ -8,6 +8,8 @@ import random
 import html
 import base64
 import re
+import unicodedata
+from difflib import SequenceMatcher
 import pandas as pd
 import boto3
 from botocore.exceptions import ClientError
@@ -264,6 +266,53 @@ def normalize_user_field(value: str | None) -> str:
         return ""
 
     return raw
+
+
+def normalize_client_name(value: str | None) -> str:
+    """Normaliza nombres de cliente para comparaciones robustas."""
+    raw = str(value or "").strip().lower()
+    if not raw:
+        return ""
+    raw = unicodedata.normalize("NFKD", raw)
+    raw = "".join(ch for ch in raw if not unicodedata.combining(ch))
+    raw = re.sub(r"[^a-z0-9\s]", " ", raw)
+    return re.sub(r"\s+", " ", raw).strip()
+
+
+def cliente_credito_match(
+    cliente_base: str | None,
+    nombres_credito_normalizados: list[str],
+    nombres_credito_lookup: set[str],
+) -> bool:
+    """
+    Determina si un cliente coincide con lista de crédito.
+    Permite diferencias muy leves con umbral conservador.
+    """
+    objetivo = normalize_client_name(cliente_base)
+    if not objetivo:
+        return False
+    if objetivo in nombres_credito_lookup:
+        return True
+
+    first_char = objetivo[0]
+    len_obj = len(objetivo)
+    for candidato in nombres_credito_normalizados:
+        if not candidato:
+            continue
+        if candidato[0] != first_char:
+            continue
+        if abs(len(candidato) - len_obj) > 2:
+            continue
+        ratio = SequenceMatcher(None, objetivo, candidato).ratio()
+        if ratio >= 0.94:
+            return True
+        if (
+            ratio >= 0.90
+            and min(len_obj, len(candidato)) >= 8
+            and (objetivo in candidato or candidato in objetivo)
+        ):
+            return True
+    return False
 
 
 def ensure_id_vendedor_column(
@@ -4595,10 +4644,89 @@ with tab2:
         df_excel = df_excel.reindex(columns=columnas_excel_orden, fill_value="")
         df_excel = df_excel.fillna("")
 
+        st.markdown("##### 🧮 Exportar Excel de Confirmados")
+        col_filtro_estado, col_filtro_forma = st.columns(2, gap="small")
+        with col_filtro_estado:
+            excluir_estado_pago_credito = st.checkbox(
+                "Excluir Estado_Pago = 💳 CREDITO",
+                value=False,
+                key="confirmados_excluir_estado_credito",
+            )
+        with col_filtro_forma:
+            excluir_forma_pago_credito_td = st.checkbox(
+                "Excluir Forma_Pago_Comprobante = Credito TD",
+                value=False,
+                key="confirmados_excluir_forma_credito_td",
+            )
+
+        clientes_credito_file = st.file_uploader(
+            "Subir Excel/CSV de clientes con crédito (usará columna 'Nombre' para subrayar filas)",
+            type=["xlsx", "xls", "csv"],
+            key="confirmados_clientes_credito_file",
+            help="Solo se utilizará la columna 'Nombre'. Se permiten diferencias leves de acentos/mayúsculas y errores mínimos.",
+        )
+
+        nombres_credito_normalizados: list[str] = []
+        if clientes_credito_file is not None:
+            try:
+                if str(clientes_credito_file.name).lower().endswith(".csv"):
+                    df_clientes_credito = pd.read_csv(clientes_credito_file)
+                else:
+                    df_clientes_credito = pd.read_excel(clientes_credito_file)
+
+                nombre_col = next(
+                    (col for col in df_clientes_credito.columns if str(col).strip().lower() == "nombre"),
+                    None,
+                )
+                if nombre_col is None:
+                    st.error("❌ El archivo de crédito debe incluir una columna llamada 'Nombre'.")
+                else:
+                    nombres_credito_normalizados = [
+                        normalize_client_name(nombre)
+                        for nombre in df_clientes_credito[nombre_col].tolist()
+                    ]
+                    nombres_credito_normalizados = [
+                        nombre for nombre in nombres_credito_normalizados if nombre
+                    ]
+                    nombres_credito_normalizados = list(dict.fromkeys(nombres_credito_normalizados))
+                    st.caption(
+                        f"Se detectaron {len(nombres_credito_normalizados)} clientes únicos de crédito para resaltar."
+                    )
+            except Exception as e:
+                st.error(f"❌ No se pudo leer el archivo de clientes con crédito: {e}")
+
         if st.button("🧮 Preparar Excel Confirmados", key="prep_excel_confirmados"):
+            df_excel_export = df_excel.copy()
+
+            if excluir_estado_pago_credito and "Estado_Pago" in df_excel_export.columns:
+                estado_pago_norm = df_excel_export["Estado_Pago"].astype(str).str.strip().str.lower()
+                df_excel_export = df_excel_export[estado_pago_norm != "💳 credito"]
+
+            if excluir_forma_pago_credito_td and "Forma_Pago_Comprobante" in df_excel_export.columns:
+                forma_pago_norm = df_excel_export["Forma_Pago_Comprobante"].astype(str).str.strip().str.lower()
+                df_excel_export = df_excel_export[forma_pago_norm != "credito td"]
+
+            mask_clientes_credito = pd.Series([False] * len(df_excel_export), index=df_excel_export.index)
+            nombres_credito_lookup = set(nombres_credito_normalizados)
+            if nombres_credito_normalizados and "Cliente" in df_excel_export.columns:
+                mask_clientes_credito = df_excel_export["Cliente"].apply(
+                    lambda nombre_cliente: cliente_credito_match(
+                        nombre_cliente,
+                        nombres_credito_normalizados,
+                        nombres_credito_lookup,
+                    )
+                )
+
             output_confirmados = BytesIO()
             with pd.ExcelWriter(output_confirmados, engine='xlsxwriter') as writer:
-                df_excel.to_excel(writer, index=False, sheet_name='Confirmados')
+                df_excel_export.to_excel(writer, index=False, sheet_name='Confirmados')
+                if mask_clientes_credito.any():
+                    workbook = writer.book
+                    worksheet = writer.sheets["Confirmados"]
+                    underline_format = workbook.add_format({"underline": 1})
+                    for excel_row, es_credito in enumerate(mask_clientes_credito.tolist(), start=1):
+                        if es_credito:
+                            worksheet.set_row(excel_row, None, underline_format)
             data_xlsx = output_confirmados.getvalue()
 
             st.download_button(


### PR DESCRIPTION
### Motivation
- Facilitar la preparación de un Excel de confirmados permitiendo excluir registros marcados como crédito por `Estado_Pago` o por `Forma_Pago_Comprobante` y visualizar fácilmente qué clientes están en una lista externa de crédito.
- Soportar casos en que los nombres en la lista de crédito y en la base de confirmados difieran por acentos, mayúsculas o errores muy leves mediante matching robusto y conservador.

### Description
- Se modificó `app_admin.py` para añadir en la vista de confirmados un bloque de exportación con dos filtros independientes: checkbox `Excluir Estado_Pago = 💳 CREDITO` y checkbox `Excluir Forma_Pago_Comprobante = Credito TD`.
- Se añadió un `st.file_uploader` para cargar un archivo `xlsx`/`xls`/`csv` con clientes con crédito y se valida que incluya una columna `Nombre` antes de usarla.
- Se implementaron las utilidades `normalize_client_name` y `cliente_credito_match` que normalizan (quita acentos, lowercasing, limpia caracteres) y aplican una comparación conservadora basada en `difflib.SequenceMatcher` con umbrales (`>= 0.94` o `>= 0.90` con condiciones adicionales) para reducir falsos positivos.
- Al generar el Excel se crea una copia filtrada y, si se subió la lista de crédito, las filas que coinciden se exportan subrayadas usando `xlsxwriter` para identificación visual.

### Testing
- Se ejecutó la comprobación de sintaxis con `python -m py_compile app_admin.py` y finalizó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e90835cd888326917cdabec76534b2)