### PR TITLE
Quitar mensaje de tip de logo en app_v y app_admin

### DIFF
--- a/app_admin.py
+++ b/app_admin.py
@@ -1635,9 +1635,6 @@ def render_brand_title(icon: str, prefix: str, fallback_suffix: str, logo_path: 
             pass
 
     st.title(f"{icon} {prefix} {fallback_suffix}")
-    st.caption(
-        f"Tip: agrega tu logo en `{logo_path}` (PNG recomendado) para reemplazar “{fallback_suffix}”."
-    )
 
 
 def render_logo_uploader(logo_path: str = "assets/td_logo.png", section_key: str = "admin") -> None:

--- a/app_v.py
+++ b/app_v.py
@@ -2800,9 +2800,6 @@ def render_brand_title(icon: str, prefix: str, fallback_suffix: str, logo_path: 
         f"<h1 class='ventas-brand-title'>{icon} {prefix} {fallback_suffix}</h1>",
         unsafe_allow_html=True,
     )
-    st.caption(
-        f"Tip: agrega tu logo en `{logo_path}` (PNG recomendado) para reemplazar “{fallback_suffix}”."
-    )
 
 
 def render_logo_uploader(logo_path: str = "assets/td_logo.png", section_key: str = "ventas") -> None:


### PR DESCRIPTION
### Motivation
- Reducir ruido en la interfaz principal eliminando el caption que sugería agregar `assets/td_logo.png`, manteniendo el título fallback cuando no hay logo.

### Description
- Eliminé la línea de `st.caption` que mostraba el mensaje `Tip: agrega tu logo en `{logo_path}`...` en ambas funciones `render_brand_title` de `app_v.py` y `app_admin.py`, sin tocar la lógica de carga de logo ni el uploader.

### Testing
- Ejecuté `python -m py_compile app_v.py app_admin.py` y ambos archivos se compilaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e922553f50832696c3cc06c25aeb95)