### PR TITLE
Add SANT1460 vendor (SANTIAGO) and update vendor list

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -180,6 +180,7 @@ USUARIOS_VALIDOS = [
     "KAREN58",
     "PAULINA57",
     "ROBERTO51",
+    "SANT1460",
     "SCHAVA",
 ]
 
@@ -197,6 +198,7 @@ VENDEDOR_NOMBRE_POR_ID = {
     "KAREN58": "KAREN JAQUELINE",
     "PAULINA57": "PAULINA TREJO",
     "ROBERTO51": "DISTRIBUCION Y UNIVERSIDADES",
+    "SANT1460": "SANTIAGO",
     "SCHAVA": "SCHAVA",
 }
 
@@ -3675,7 +3677,7 @@ VENDEDORES_LIST = sorted([
     "JUAN CASTILLEJO",
     "KAREN JAQUELINE",
     "PAULINA TREJO",
-    "ROBERTO LEGRA",
+    "SANTIAGO",
 ])
 
 # Initialize session state for vendor (default linked to logged-in vendor ID)


### PR DESCRIPTION
### Motivation
- Introduce a new valid vendor ID and ensure the display lists and mappings reflect the new vendor name.

### Description
- Added `SANT1460` to `USUARIOS_VALIDOS`, added `"SANT1460": "SANTIAGO"` to `VENDEDOR_NOMBRE_POR_ID`, and replaced `"ROBERTO LEGRA"` with `"SANTIAGO"` in `VENDEDORES_LIST`.

### Testing
- Ran the project's automated test suite and static checks; all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9247eeb788326bba3abcf5931d6e2)