### PR TITLE
Remove 'Credito TD' filter checkbox from Confirmados export

### DIFF
--- a/app_admin.py
+++ b/app_admin.py
@@ -4572,29 +4572,17 @@ with tab2:
         )
 
         st.markdown("##### 🧮 Exportar Excel de Confirmados")
-        col_filtro_estado, col_filtro_forma = st.columns(2, gap="small")
-        with col_filtro_estado:
-            excluir_estado_pago_credito = st.checkbox(
-                "Excluir Estado_Pago = 💳 CREDITO",
-                value=False,
-                key="confirmados_excluir_estado_credito",
-            )
-        with col_filtro_forma:
-            excluir_forma_pago_credito_td = st.checkbox(
-                "Excluir Forma_Pago_Comprobante = Credito TD",
-                value=False,
-                key="confirmados_excluir_forma_credito_td",
-            )
+        excluir_estado_pago_credito = st.checkbox(
+            "Excluir Estado_Pago = 💳 CREDITO",
+            value=False,
+            key="confirmados_excluir_estado_credito",
+        )
 
         df_confirmados_filtrados = df_confirmados_visible.copy()
         if excluir_estado_pago_credito and "Estado_Pago" in df_confirmados_filtrados.columns:
             estado_pago_norm = df_confirmados_filtrados["Estado_Pago"].astype(str).str.strip().str.lower()
             df_confirmados_filtrados = df_confirmados_filtrados[estado_pago_norm != "💳 credito"]
-        if excluir_forma_pago_credito_td and "Forma_Pago_Comprobante" in df_confirmados_filtrados.columns:
-            forma_pago_norm = df_confirmados_filtrados["Forma_Pago_Comprobante"].astype(str).str.strip().str.lower()
-            df_confirmados_filtrados = df_confirmados_filtrados[forma_pago_norm != "credito td"]
-
-        st.caption(f"Mostrando {len(df_confirmados_filtrados)} pedidos confirmados con filtros aplicados.")
+        st.caption(f"Mostrando {len(df_confirmados_filtrados)} pedidos confirmados con filtro aplicado.")
 
         clientes_credito_file = st.file_uploader(
             "Subir Excel/CSV de clientes con crédito (se usará la columna B para subrayar filas)",


### PR DESCRIPTION
### Motivation
- Simplify the export filter UI in the "📥 Confirmados" tab by removing the `Forma_Pago_Comprobante = Credito TD` option that duplicated filtering logic and caused confusion.
- Make the export filtering behavior consistent by relying on the existing `Estado_Pago` exclusion control.

### Description
- Removed the `Excluir Forma_Pago_Comprobante = Credito TD` checkbox and the associated layout code in `app_admin.py`.
- Deleted the dataframe branch that filtered out rows where `Forma_Pago_Comprobante` normalized to `"credito td"`.
- Updated the helper caption to the singular form `"Mostrando {len(...)} pedidos confirmados con filtro aplicado."`.

### Testing
- Ran `python -m py_compile app_admin.py` and it completed successfully with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e95684c6a08326bf2cde209fde35aa)