### PR TITLE
Pedir confirmación si se intenta registrar un pedido sin archivos adjuntos

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -4849,6 +4849,38 @@ with tab1:
         )
 
     should_process_submission = submit_button
+    expected_auto_route_attachment = usa_hoja_ruta_local and not is_local_pasa_bodega
+    no_adjuntos_capturados = not (uploaded_files or comprobante_pago_files or comprobante_cliente)
+
+    if submit_button and no_adjuntos_capturados and not expected_auto_route_attachment and not submission_payload_override:
+        st.session_state["pedido_confirm_without_attachments_pending"] = True
+        should_process_submission = False
+
+    if st.session_state.get("pedido_confirm_without_attachments_pending") and not should_process_submission:
+        st.warning("⚠️ Este pedido se registrará SIN archivos adjuntos. Confirma si deseas continuar.")
+        confirm_col, cancel_col = st.columns(2)
+        with confirm_col:
+            confirm_without_attachments = st.button(
+                "✅ Sí, registrar sin adjuntos",
+                key="confirm_submit_without_attachments",
+            )
+        with cancel_col:
+            cancel_without_attachments = st.button(
+                "✏️ No, volver a captura",
+                key="cancel_submit_without_attachments",
+            )
+
+        if confirm_without_attachments:
+            st.session_state.pop("pedido_confirm_without_attachments_pending", None)
+            should_process_submission = True
+        elif cancel_without_attachments:
+            st.session_state.pop("pedido_confirm_without_attachments_pending", None)
+            set_pedido_submission_status(
+                "warning",
+                "⚠️ Se canceló el envío para que puedas adjuntar archivos antes de registrar.",
+            )
+            st.rerun()
+
     if route_post_confirm_notice:
         st.session_state.pop(LOCAL_ROUTE_POST_CONFIRM_NOTICE_KEY, None)
 


### PR DESCRIPTION
### Motivation

- Evitar registros accidentales de pedidos sin archivos adjuntos cuando la captura requiere documentos, salvo en el caso de hojas de ruta locales que se adjuntan automáticamente.

### Description

- Añadida lógica que detecta si el formulario se envía sin adjuntos y, salvo excepciones de hoja de ruta local (`usa_hoja_ruta_local` y `not is_local_pasa_bodega`) o si hay una sobrescritura del payload, bloquea el procesamiento y marca una confirmación pendiente en `st.session_state`.
- Se muestra una advertencia en la UI y se exponen dos botones para que el usuario confirme `confirm_submit_without_attachments` o cancele `cancel_submit_without_attachments` la entrega sin archivos.
- Al confirmar se continúa con el procesamiento, y al cancelar se restablece el estado con `set_pedido_submission_status` mostrando un aviso y se hace `st.rerun()` para volver a la captura.
- Las nuevas variables de control añadidas son `expected_auto_route_attachment` y `no_adjuntos_capturados` para clarificar la condición de chequeo.

### Testing

- Ejecutado el suite de pruebas automatizadas con `pytest -q` y todas las pruebas existentes pasaron correctamente.
- Ejecutado el linteo/pre-commit (`pre-commit run --all-files`) y no se reportaron fallos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f12bd996548326b90384e823c74464)