### PR TITLE
Fix: Fijar y mostrar siempre el Cliente en Nueva Ruta (pedido local)

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -6966,10 +6966,15 @@ with tab2:
                     if pending_tab2_cliente is not None:
                         st.session_state["tab2_local_route_client_search"] = pending_tab2_cliente
 
-                    tab2_cliente = st.text_input(
+                    tab2_cliente_fijo = str(selected_row_data.get("Cliente", "") or "").strip()
+                    if tab2_cliente_fijo:
+                        st.session_state["tab2_local_route_client_search"] = tab2_cliente_fijo
+                    tab2_cliente = str(st.session_state.get("tab2_local_route_client_search", "") or "").strip()
+                    st.text_input(
                         "🤝 Cliente",
                         key="tab2_local_route_client_search",
-                        placeholder="Escribe o pega el nombre del cliente",
+                        disabled=True,
+                        help="Cliente fijo del pedido seleccionado para modificación de Nueva Ruta.",
                     )
                     normalized_tab2_cliente = normalize_client_history_text(tab2_cliente)
                     previous_tab2_query = st.session_state.get("tab2_local_route_last_query", "")


### PR DESCRIPTION
### Motivation
- Evitar que en Tab 2 → "Modificar pedido" con tipo de modificación `Nueva Ruta` para pedidos locales el campo `Cliente` quede vacío o cambie inesperadamente al cambiar la vista. 
- Forzar que el `Cliente` corresponda al cliente del pedido seleccionado y no pueda editarse manualmente en ese flujo.

### Description
- Se sincroniza `st.session_state["tab2_local_route_client_search"]` con `selected_row_data.get("Cliente")` cuando existe para asegurar valor por defecto consistente. 
- Se muestra el campo `tab2_local_route_client_search` como un `st.text_input(..., disabled=True)` para que el cliente quede fijo en el flujo de `Nueva Ruta` y no sea editable. 
- Se usa el valor sincronizado para normalizar y buscar coincidencias con `get_clientes_locales_matches_with_fallback_refresh`, manteniendo la lógica de coincidencias y recarga. 
- Cambios aplicados en `app_v.py` alrededor de la sección de Tab 2 (hoja de ruta local / tipo de modificación `Nueva Ruta`).

### Testing
- Se ejecutó `python -m py_compile app_v.py` y la comprobación de sintaxis pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3a8fc06dc8326b619602f3eb9b000)