### PR TITLE
Sanitize Tab 1 attachment filenames before S3 upload

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -2486,7 +2486,10 @@ def upload_files_or_fail(files, s3_client, bucket, prefix):
     uploaded_urls = []
     for file_obj in files or []:
         file_obj.seek(0)
-        safe_name = file_obj.name.replace(" ", "_")
+        original_name = Path(file_obj.name).name
+        stem = re.sub(r"[^A-Za-z0-9._-]+", "_", Path(original_name).stem).strip("._")
+        suffix = re.sub(r"[^A-Za-z0-9.]", "", Path(original_name).suffix)
+        safe_name = f"{stem or 'archivo'}{suffix}".replace("..", ".")
         s3_key = f"{prefix}{safe_name}"
         ok, url, error = upload_file_to_s3(s3_client, bucket, file_obj, s3_key)
         if not ok:


### PR DESCRIPTION
### Motivation
- Prevent upload failures caused by filenames with spaces or unsafe characters when building S3 keys for Tab 1 attachments.
- Make generated S3 object keys deterministic and safer for downstream APIs and integrations.

### Description
- Replace the previous simple `file_obj.name.replace(" ", "_")` with a sanitization routine in `upload_files_or_fail` that extracts the `original_name`, normalizes the `stem` with `re.sub(r"[^A-Za-z0-9._-]+","_", ...)`, cleans the `suffix` (extension), and falls back to `archivo` when the name would be empty.
- Ensure the final `safe_name` removes accidental `..` sequences and is concatenated with `prefix` to form the `s3_key` before calling the existing `upload_file_to_s3` flow.

### Testing
- Ran `python -m py_compile app_v.py` and it succeeded.
- Verified repository changes were staged and committed after cleaning `__pycache__` (commit message: "Sanitize uploaded attachment filenames for S3 keys").

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3ac2f79f08326aa10ddf06523f42e)