### PR TITLE
Sanitize uploaded filenames and add guidance for HTTP 400 upload errors

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -2486,7 +2486,10 @@ def upload_files_or_fail(files, s3_client, bucket, prefix):
     uploaded_urls = []
     for file_obj in files or []:
         file_obj.seek(0)
-        safe_name = file_obj.name.replace(" ", "_")
+        original_name = Path(file_obj.name).name
+        stem = re.sub(r"[^A-Za-z0-9._-]+", "_", Path(original_name).stem).strip("._")
+        suffix = re.sub(r"[^A-Za-z0-9.]", "", Path(original_name).suffix)
+        safe_name = f"{stem or 'archivo'}{suffix}".replace("..", ".")
         s3_key = f"{prefix}{safe_name}"
         ok, url, error = upload_file_to_s3(s3_client, bucket, file_obj, s3_key)
         if not ok:
@@ -5196,6 +5199,14 @@ with tab1:
                 error_message = status_data.get("message", "❌ Falla al subir el pedido.")
                 if detail:
                     error_message = f"{error_message}\n\n🔍 Detalle: {detail}"
+                detail_text = f"{error_message} {detail or ''}".lower()
+                if "400" in detail_text or "request failed" in detail_text or "axios" in detail_text:
+                    error_message = (
+                        f"{error_message}\n\n"
+                        "💡 Sugerencia: este error 400 suele ser por red/restricciones del navegador o sesión. "
+                        "Pide intentar: 1) recargar sesión, 2) cambiar de red (sin VPN/proxy), "
+                        "3) renombrar el archivo simple (ej. factura_123.pdf) y 4) volver a subir."
+                    )
                 st.error(error_message)
                 if should_toast:
                     st.toast("❌ Error al registrar el pedido")


### PR DESCRIPTION
### Motivation

- Ensure uploaded filenames are safe for S3 keys by removing path components and illegal characters and to avoid accidental directory traversal or malformed names when calling `upload_file_to_s3` via `upload_files_or_fail`.
- Provide clearer, actionable guidance to users when a 400-style upload error occurs (often caused by network/session/browser restrictions) to reduce repeated failed submissions.

### Description

- Replace naive `file_obj.name.replace(" ", "_")` with robust sanitization in `upload_files_or_fail` that extracts the base name via `Path`, sanitizes the stem with `re` to allow only `[A-Za-z0-9._-]`, strips leading/trailing dots/underscores, preserves a cleaned suffix, uses a fallback name `archivo` when the stem is empty, and collapses accidental `..` sequences. 
- Detect 400-like upload failures by lowercasing `detail` and checking for `"400"`, `"request failed"`, or `"axios"`, and append a Spanish hint to the displayed `error_message` suggesting steps like reloading the session, changing network (no VPN/proxy), renaming the file to a simple name (for example `factura_123.pdf`), and retrying the upload.

### Testing

- Ran the project's automated unit test suite and linters against the modified files and the test suite completed without failures. 
- Performed automated file-name sanitization unit checks to ensure `upload_files_or_fail` produces expected `safe_name` outputs for inputs containing spaces, path separators, illegal characters, or empty stems, and those checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3ac2f79f08326aa10ddf06523f42e)