### PR TITLE
Seed and lock `Cliente` field for "Nueva Ruta" from selected order

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -6966,10 +6966,15 @@ with tab2:
                     if pending_tab2_cliente is not None:
                         st.session_state["tab2_local_route_client_search"] = pending_tab2_cliente
 
-                    tab2_cliente = st.text_input(
+                    tab2_cliente_fijo = str(selected_row_data.get("Cliente", "") or "").strip()
+                    if tab2_cliente_fijo:
+                        st.session_state["tab2_local_route_client_search"] = tab2_cliente_fijo
+                    tab2_cliente = str(st.session_state.get("tab2_local_route_client_search", "") or "").strip()
+                    st.text_input(
                         "🤝 Cliente",
                         key="tab2_local_route_client_search",
-                        placeholder="Escribe o pega el nombre del cliente",
+                        disabled=True,
+                        help="Cliente fijo del pedido seleccionado para modificación de Nueva Ruta.",
                     )
                     normalized_tab2_cliente = normalize_client_history_text(tab2_cliente)
                     previous_tab2_query = st.session_state.get("tab2_local_route_last_query", "")
@@ -7051,7 +7056,6 @@ with tab2:
                                 )
                                 st.rerun()
                     elif tab2_cliente.strip():
-                        st.caption("🆕 Cliente nuevo sin historial local.")
                         st.session_state["tab2_local_route_selected_history_label"] = None
                         st.session_state["tab2_local_route_selected_history_row"] = None
 

--- a/app_v.py
+++ b/app_v.py
@@ -6983,6 +6983,9 @@ with tab2:
                         st.session_state["tab2_local_route_selected_history_label"] = None
                         st.session_state["tab2_local_route_selected_history_row"] = None
 
+                    if tab2_cliente:
+                        st.caption("✅ Cliente con historial local.")
+
                     tab2_matches, tab2_forced_refresh_used = get_clientes_locales_matches_with_fallback_refresh(
                         tab2_cliente,
                         session_prefix="tab2_local_route_client_search",


### PR DESCRIPTION
### Motivation
- Ensure the local-route creation flow for `Nueva Ruta` uses the `Cliente` from the selected order and prevents accidental edits by making the field read-only.

### Description
- Populate `st.session_state['tab2_local_route_client_search']` from `selected_row_data.get('Cliente')`, present the client in a disabled `st.text_input`, and remove the previous "new client" caption.

### Testing
- Ran the automated test suite with `pytest` and static checks with `flake8`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3a8fc06dc8326b619602f3eb9b000)