### PR TITLE
Prefill and lock tab2 client field for 'Nueva Ruta' using selected order

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -6966,10 +6966,15 @@ with tab2:
                     if pending_tab2_cliente is not None:
                         st.session_state["tab2_local_route_client_search"] = pending_tab2_cliente
 
-                    tab2_cliente = st.text_input(
+                    tab2_cliente_fijo = str(selected_row_data.get("Cliente", "") or "").strip()
+                    if tab2_cliente_fijo:
+                        st.session_state["tab2_local_route_client_search"] = tab2_cliente_fijo
+                    tab2_cliente = str(st.session_state.get("tab2_local_route_client_search", "") or "").strip()
+                    st.text_input(
                         "🤝 Cliente",
                         key="tab2_local_route_client_search",
-                        placeholder="Escribe o pega el nombre del cliente",
+                        disabled=True,
+                        help="Cliente fijo del pedido seleccionado para modificación de Nueva Ruta.",
                     )
                     normalized_tab2_cliente = normalize_client_history_text(tab2_cliente)
                     previous_tab2_query = st.session_state.get("tab2_local_route_last_query", "")
@@ -7051,7 +7056,6 @@ with tab2:
                                 )
                                 st.rerun()
                     elif tab2_cliente.strip():
-                        st.caption("🆕 Cliente nuevo sin historial local.")
                         st.session_state["tab2_local_route_selected_history_label"] = None
                         st.session_state["tab2_local_route_selected_history_row"] = None
 


### PR DESCRIPTION
### Motivation
- Ensure the "Nueva Ruta" local route flow uses the client from the selected order as a fixed value to avoid accidental edits and to keep the route tied to the selected record.

### Description
- Prefill the local route client from `selected_row_data.get("Cliente")` into `st.session_state["tab2_local_route_client_search"]` when available and make the `tab2` client input disabled with a help message. 

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3a8fc06dc8326b619602f3eb9b000)