### PR TITLE
Persistir Monto_Comprobante y precargar ADEUDO ANT. en 'Nueva Ruta' (app_v.py)

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -6887,9 +6887,15 @@ with tab2:
                     except (TypeError, ValueError):
                         st.session_state[f"{tab2_route_prefix}_total_factura"] = 0.0
                     try:
-                        st.session_state[f"{tab2_route_prefix}_adeudo_anterior"] = float(selected_row_data.get("Adeudo_Anterior", 0) or 0)
+                        st.session_state[f"{tab2_route_prefix}_adeudo_anterior"] = float(selected_row_data.get("Monto_Comprobante", 0) or 0)
                     except (TypeError, ValueError):
                         st.session_state[f"{tab2_route_prefix}_adeudo_anterior"] = 0.0
+                    try:
+                        st.session_state[f"{tab2_route_prefix}_monto_comprobante_original"] = float(selected_row_data.get("Monto_Comprobante", 0) or 0)
+                    except (TypeError, ValueError):
+                        st.session_state[f"{tab2_route_prefix}_monto_comprobante_original"] = 0.0
+                    st.session_state[f"{tab2_route_prefix}_total_factura_original"] = float(st.session_state.get(f"{tab2_route_prefix}_total_factura", 0) or 0)
+                    st.session_state[f"{tab2_route_prefix}_adeudo_anterior_original"] = float(st.session_state.get(f"{tab2_route_prefix}_adeudo_anterior", 0) or 0)
                     st.session_state[f"{tab2_route_prefix}_referencias"] = str(selected_row_data.get("Referencias", "") or "").strip()
                     turno_local_default_tab2 = str(selected_row_data.get("Turno", "") or "").strip()
                     if turno_local_default_tab2 not in local_shift_options_tab2:
@@ -7509,7 +7515,16 @@ with tab2:
                                         "Referencias": tab2_route_payload.get("referencias", ""),
                                         "Forma_Pago_Comprobante": tab2_route_payload.get("forma_pago", ""),
                                         "Estado_Pago": st.session_state.get("tab2_local_estado_pago", "🔴 No Pagado"),
-                                        "Monto_Comprobante": f"{float(st.session_state.get(f'{tab2_route_prefix}_total_factura', 0) or 0) + float(st.session_state.get(f'{tab2_route_prefix}_adeudo_anterior', 0) or 0):.2f}",
+                                                                                "Monto_Comprobante": (
+                                            f"{(float(st.session_state.get(f'{tab2_route_prefix}_total_factura', 0) or 0) + float(st.session_state.get(f'{tab2_route_prefix}_adeudo_anterior', 0) or 0)):.2f}"
+                                            if (
+                                                float(st.session_state.get(f'{tab2_route_prefix}_total_factura', 0) or 0)
+                                                != float(st.session_state.get(f'{tab2_route_prefix}_total_factura_original', 0) or 0)
+                                                or float(st.session_state.get(f'{tab2_route_prefix}_adeudo_anterior', 0) or 0)
+                                                != float(st.session_state.get(f'{tab2_route_prefix}_adeudo_anterior_original', 0) or 0)
+                                            )
+                                            else f"{float(st.session_state.get(f'{tab2_route_prefix}_monto_comprobante_original', 0) or 0):.2f}"
+                                        ),
                                     }
                                     for col_name, col_value in tab2_route_fields_map.items():
                                         if col_exists(col_name) and str(actual_row.get(col_name, "")) != str(col_value):


### PR DESCRIPTION
### Motivation
- Al modificar un pedido local con tipo "Nueva Ruta" se requiere que el campo `💸 ADEUDO ANT.` refleje el `Monto_Comprobante` actual y que `Monto_Comprobante` solo cambie cuando el usuario modifique montos explícitamente.

### Description
- En `app_v.py` se cambia la carga inicial de `ADEUDO ANT.` para precargar el valor de `Monto_Comprobante` en lugar de `Adeudo_Anterior` y se agregan claves de `session_state` para almacenar los montos originales (`..._monto_comprobante_original`, `..._total_factura_original`, `..._adeudo_anterior_original`).
- Al construir el mapa de campos para actualizar la hoja de ruta, `Monto_Comprobante` ahora se calcula como `TOTAL FACTURA + ADEUDO ANT.` únicamente si `TOTAL FACTURA` o `ADEUDO ANT.` fueron modificados respecto a sus valores originales; en caso contrario se preserva el `Monto_Comprobante` original.
- Los cambios afectan la sección de carga y el bloque que prepara `tab2_route_fields_map` cuando `apply_local_route_update` está activo.

### Testing
- Se ejecutó `python -m py_compile app_v.py` y la verificación de sintaxis completó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3b9a98dd4832688a5c0579c95d5ed)