### PR TITLE
Preserva y precarga notas en Casos Especiales al capturar Folio Nuevo

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -8318,10 +8318,16 @@ with tab4:
                                 placeholder="Ej. F197176",
                             )
 
+                            notas_key = f"{row_key}_notas_devolucion"
+                            nota_existente = str(row.get("Modificacion_Surtido", "") or "").strip()
+                            if notas_key not in st.session_state:
+                                st.session_state[notas_key] = nota_existente
+
                             notas_devolucion = st.text_area(
                                 "✍️ Notas de Devolucion Pendiente",
-                                key=f"{row_key}_notas_devolucion",
+                                key=notas_key,
                                 height=100,
+                                help="Se carga el comentario previo para que puedas conservarlo, editarlo, eliminarlo o agregar más información.",
                             )
                             direccion_guia_retorno_pendiente = st.text_area(
                                 "📬 Dirección Guia_Retorno (Opcional)",


### PR DESCRIPTION
### Motivation
- Al abrir un caso en `Casos Especiales -> Devoluciones sin refacturar` se quería que el campo de notas mostrara y preservara el comentario previo almacenado en `Modificacion_Surtido` para que el usuario pueda mantener, editar o eliminar el texto existente sin perderlo.

### Description
- En `app_v.py` se creó `notas_key` para precargar `Modificacion_Surtido` en `st.session_state` y se usa ese key en el `st.text_area` de `Notas de Devolucion Pendiente`, además se agregó un `help` para explicar el comportamiento al usuario.

### Testing
- Se ejecutó `python -m py_compile app_v.py` y la compilación fue exitosa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa0a72541883268f5c0d18a5c4b4bb)