### PR TITLE
Stop auto-updating `Estado` and clearing `Completados_Limpiado` when saving devoluciones

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -8436,19 +8436,6 @@ with tab4:
                                             "values": [[updated_adjuntos]],
                                         })
 
-                                    if col_exists("Estado"):
-                                        cell_updates.append({
-                                            "range": rowcol_to_a1(row_idx, col_idx("Estado")),
-                                            "values": [["✏️ Modificación"]],
-                                        })
-
-                                    completado_actual = str(current_row.get("Completados_Limpiado", "")).strip().lower()
-                                    if col_exists("Completados_Limpiado") and completado_actual in {"si", "sí"}:
-                                        cell_updates.append({
-                                            "range": rowcol_to_a1(row_idx, col_idx("Completados_Limpiado")),
-                                            "values": [[""]],
-                                        })
-
                                     if cell_updates:
                                         safe_batch_update(ws_casos_ref, cell_updates)
 


### PR DESCRIPTION
### Motivation

- Prevent accidental overwrites of workflow status and completed flags when saving new folios and attachments. 
- Preserve existing values in `Estado` and `Completados_Limpiado` to avoid losing manual state set by users.

### Description

- Removed the automatic update that set the `Estado` column to `"✏️ Modificación"` during folio save. 
- Removed the logic that cleared `Completados_Limpiado` when its current value was `"si"` or `"sí"`. 
- Kept other behavior intact including uploading files to S3, updating `Adjuntos`/`Adjuntos_Surtido`, and clearing related session state.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa742d28f48326a4f08826beaa528b)