### PR TITLE
Mitiga sobreconsumo de memoria en `app_admin.py` sin cambiar la lógica funcional

### DIFF
--- a/app_admin.py
+++ b/app_admin.py
@@ -27,6 +27,8 @@ from urllib.parse import urlparse, unquote, quote
 from contextlib import suppress
 from streamlit.runtime.scriptrunner import StopException
 import numbers
+import gc
+import sys
 
 # Reintentos robustos para Google Sheets
 RETRIABLE_CODES = {429, 500, 502, 503, 504}
@@ -1011,10 +1013,11 @@ def release_app_memory() -> None:
 
     st.cache_data.clear()
     st.cache_resource.clear()
+    gc.collect()
 
 
 def estimate_session_state_df_memory_mb() -> float:
-    """Estima memoria total en MB ocupada por DataFrames en session_state."""
+    """Estima memoria total en MB ocupada por DataFrames y blobs en session_state."""
     total_bytes = 0
     for value in st.session_state.values():
         if isinstance(value, pd.DataFrame):
@@ -1022,13 +1025,18 @@ def estimate_session_state_df_memory_mb() -> float:
                 total_bytes += int(value.memory_usage(deep=True).sum())
             except Exception:
                 continue
+        elif isinstance(value, (bytes, bytearray, memoryview, str)):
+            total_bytes += sys.getsizeof(value)
+        elif isinstance(value, (list, tuple, set, dict)):
+            # Estimación ligera (shallow) para colecciones temporales grandes.
+            total_bytes += sys.getsizeof(value)
     return total_bytes / (1024 * 1024)
 
 
 def maybe_run_proactive_memory_guard(
     *,
-    threshold_mb: float = 180.0,
-    min_interval_sec: int = 120,
+    threshold_mb: float = 120.0,
+    min_interval_sec: int = 90,
 ) -> None:
     """
     Limpieza preventiva: si los DataFrames en session_state superan el umbral,


### PR DESCRIPTION
### Motivation
- Evitar que la aplicación caiga por límites de memoria de Streamlit actuando antes de alcanzar picos de consumo.
- Detectar presión de memoria real en `st.session_state` más allá de solo `DataFrame` para activar limpiezas preventivas.
- Liberar memoria de forma más confiable tras limpiar estado y cachés para reducir reinicios inesperados.

### Description
- Se agregan los imports `gc` y `sys` para permitir recolección explícita y estimación de tamaño de objetos.
- `release_app_memory()` ahora ejecuta `gc.collect()` después de limpiar `st.session_state` y borrar caches con `st.cache_data.clear()` y `st.cache_resource.clear()`.
- `estimate_session_state_df_memory_mb()` amplía la estimación contando además de `pd.DataFrame` a `bytes`/`bytearray`/`memoryview`/`str` y hace una estimación superficial de colecciones (`list`, `tuple`, `set`, `dict`) usando `sys.getsizeof()`.
- `maybe_run_proactive_memory_guard()` se vuelve más proactiva bajando el umbral a `threshold_mb = 120.0` y la ventana mínima a `min_interval_sec = 90` para disparar limpiezas antes.

### Testing
- Se ejecutó `python -m py_compile app_admin.py` para validar la sintaxis y compilación del módulo, y la comprobación final fue satisfactoria.
- No se ejecutaron pruebas de integración o de carga en este cambio; el alcance fue reducir riesgos de memoria sin alterar la lógica de negocio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb717cc6cc8326834e43bd5c486d08)