### PR TITLE
Improve session memory handling and caching for confirmed sheets

### DIFF
--- a/app_admin.py
+++ b/app_admin.py
@@ -27,6 +27,8 @@ from urllib.parse import urlparse, unquote, quote
 from contextlib import suppress
 from streamlit.runtime.scriptrunner import StopException
 import numbers
+import gc
+import sys
 
 # Reintentos robustos para Google Sheets
 RETRIABLE_CODES = {429, 500, 502, 503, 504}
@@ -1011,10 +1013,11 @@ def release_app_memory() -> None:
 
     st.cache_data.clear()
     st.cache_resource.clear()
+    gc.collect()
 
 
 def estimate_session_state_df_memory_mb() -> float:
-    """Estima memoria total en MB ocupada por DataFrames en session_state."""
+    """Estima memoria total en MB ocupada por DataFrames y blobs en session_state."""
     total_bytes = 0
     for value in st.session_state.values():
         if isinstance(value, pd.DataFrame):
@@ -1022,13 +1025,18 @@ def estimate_session_state_df_memory_mb() -> float:
                 total_bytes += int(value.memory_usage(deep=True).sum())
             except Exception:
                 continue
+        elif isinstance(value, (bytes, bytearray, memoryview, str)):
+            total_bytes += sys.getsizeof(value)
+        elif isinstance(value, (list, tuple, set, dict)):
+            # Estimación ligera (shallow) para colecciones temporales grandes.
+            total_bytes += sys.getsizeof(value)
     return total_bytes / (1024 * 1024)
 
 
 def maybe_run_proactive_memory_guard(
     *,
-    threshold_mb: float = 180.0,
-    min_interval_sec: int = 120,
+    threshold_mb: float = 120.0,
+    min_interval_sec: int = 90,
 ) -> None:
     """
     Limpieza preventiva: si los DataFrames en session_state superan el umbral,
@@ -3964,7 +3972,7 @@ with tab2:
 
         return trabajo
 
-    @st.cache_data(show_spinner=False)
+    @st.cache_data(show_spinner=False, ttl=300, max_entries=1)
     def cargar_confirmados_guardados_cached(sheet_id: str, ws_name: str, _nonce: int):
         """
         Lee la hoja de confirmados con reintentos (safe_open_worksheet) y guarda snapshot.


### PR DESCRIPTION
### Motivation
- Reduce unexpected Streamlit restarts by more aggressively freeing memory and improving session memory estimation.
- Include non-DataFrame blobs and collections in the memory estimate so proactive cleanup triggers earlier for large uploads/objects.
- Prevent long-lived cached snapshots from consuming memory and ensure cached confirmed-sheet reads expire sooner.

### Description
- Import `gc` and `sys` and call `gc.collect()` in `release_app_memory()` to force a garbage collection pass after clearing session state and caches. 
- Extend `estimate_session_state_df_memory_mb()` to account for `bytes`, `bytearray`, `memoryview`, `str` and shallow sizes of `list`, `tuple`, `set`, and `dict` using `sys.getsizeof()` in addition to `DataFrame.memory_usage()`.
- Make the proactive guard more aggressive by lowering `threshold_mb` from `180.0` to `120.0` and `min_interval_sec` from `120` to `90` in `maybe_run_proactive_memory_guard()`.
- Add caching controls to `cargar_confirmados_guardados_cached()` by setting `@st.cache_data(show_spinner=False, ttl=300, max_entries=1)` to limit entry count and expire snapshots after 5 minutes.

### Testing
- Ran the project's automated test suite with `pytest -q`, and all tests passed.
- Executed an automated memory regression script that populates `st.session_state` with large DataFrames and blobs and confirmed `maybe_run_proactive_memory_guard()` triggers cleanup and `release_app_memory()` reclaims memory as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb717cc6cc8326834e43bd5c486d08)