### PR TITLE
Always set `Estado` to 🟡 Pendiente (remove 'No Aplica' special-case)

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -5879,7 +5879,7 @@ with tab1:
                 elif header == "Adjuntos_Surtido":
                     values.append("")
                 elif header == "Estado":
-                    values.append("No Aplica" if es_envio_historico_especial else "🟡 Pendiente")
+                    values.append("🟡 Pendiente")
                 elif header == "Estado_Pago":
                     if tipo_envio in ["🚚 Pedido Foráneo", "🏙️ Pedido CDMX", "📍 Pedido Local"] or (
                         tipo_envio == "🔁 Devolución" and normalize_tipo_envio_original(tipo_envio_original) == "📍 Pedido Local"


### PR DESCRIPTION
### Motivation
- The export logic previously emitted `"No Aplica"` for `Estado` when `es_envio_historico_especial` was true, but the requirement is to treat these rows uniformly as pending, so the special-case was removed.

### Description
- Replaced `values.append("No Aplica" if es_envio_historico_especial else "🟡 Pendiente")` with `values.append("🟡 Pendiente")` in the `Estado` branch so `Estado` is always set to `🟡 Pendiente`.

### Testing
- Ran the project's automated test suite (`pytest`) after the change and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcb0885ec48326ad336800e3d7d354)