### PR TITLE
Activar por defecto "Mostrar últimos 4 días" en pestaña Modificar Pedido

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -6788,6 +6788,9 @@ with tab2:
                 selected_vendedor_mod = "Todos"
 
         with col2:
+            if "tab2_modificar_filtro_ultimos_4_dias" not in st.session_state:
+                st.session_state["tab2_modificar_filtro_ultimos_4_dias"] = True
+
             (
                 fecha_inicio_mod,
                 fecha_fin_mod,


### PR DESCRIPTION
### Motivation
- Hacer que el checkbox `Mostrar últimos 4 días` venga seleccionado por defecto en la pestaña **Modificar Pedido Existente** para facilitar la búsqueda de pedidos recientes.

### Description
- Inicializa `st.session_state["tab2_modificar_filtro_ultimos_4_dias"] = True` (solo si la clave no existe) antes de llamar a `render_date_filter_controls(..., recent_days_option=4)` en `app_v.py` para conservar la interacción del usuario después del primer render.

### Testing
- Ejecutado `python -m py_compile app_v.py` y la comprobación de sintaxis pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe4030cb2c8326b23d34d0f2b70332)