### PR TITLE
Serialize DHL manual address when present and clarify checkbox caption

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -5601,8 +5601,6 @@ with tab1:
                     st.session_state["pedido_submit_disabled"] = False
                     st.session_state.pop("pedido_submit_disabled_at", None)
                     rerun_with_pedido_loading("⏳ Recargando formulario...")
-                if (not solicitar_guia_manual) and missing_dhl_fields:
-                    st.caption("ℹ️ No se solicitó guía manual en este pedido. Los campos DHL faltantes no bloquean el registro.")
                 direccion_guia_retorno_serializada = build_dhl_mexico_address_payload(dhl_address_payload)
                 direccion_guia_retorno = (
                     direccion_guia_retorno_serializada

--- a/app_v.py
+++ b/app_v.py
@@ -4672,7 +4672,7 @@ with tab1:
         if tipo_envio == "🚚 Pedido Foráneo":
             with st.expander("📬 Dirección guía Manual  (Obligatorio al Solicitar Guia)", expanded=False):
                 solicitar_guia_manual = st.checkbox("✅ Solicitar guía manual en este pedido", key="foraneo_solicitar_guia_manual")
-                st.caption("SI NO SE ACTIVA ESTE CHECK NO SE ENVIARA LA NOTIFICACIÓN A BODEGA.")
+                st.caption("Si capturas dirección, se enviará tal como se escribió aunque no actives el check.")
                 st.markdown("**CAMPOS OBLIGATORIOS DHL (MÉXICO)**")
                 col_dhl_1, col_dhl_2 = st.columns(2)
                 with col_dhl_1:
@@ -5603,9 +5603,10 @@ with tab1:
                     rerun_with_pedido_loading("⏳ Recargando formulario...")
                 if (not solicitar_guia_manual) and missing_dhl_fields:
                     st.caption("ℹ️ No se solicitó guía manual en este pedido. Los campos DHL faltantes no bloquean el registro.")
+                direccion_guia_retorno_serializada = build_dhl_mexico_address_payload(dhl_address_payload)
                 direccion_guia_retorno = (
-                    build_dhl_mexico_address_payload(dhl_address_payload)
-                    if solicitar_guia_manual
+                    direccion_guia_retorno_serializada
+                    if solicitar_guia_manual or direccion_guia_retorno_serializada.strip()
                     else ""
                 )
 


### PR DESCRIPTION
### Motivation
- Ensure a manually-entered DHL address is preserved and returned even if the "Solicitar guía manual" checkbox is not checked, and make the UI caption clearer about capture behavior.

### Description
- Updated the checkbox caption to: "Si capturas dirección, se enviará tal como se escribió aunque no actives el check." to clarify behavior for users.
- Added `direccion_guia_retorno_serializada = build_dhl_mexico_address_payload(dhl_address_payload)` to always produce a serialized DHL address payload when fields are present.
- Changed the `direccion_guia_retorno` assignment to use the serialized payload when `solicitar_guia_manual` is true or when `direccion_guia_retorno_serializada.strip()` is non-empty, so the address is returned even if the checkbox is not checked.

### Testing
- Ran the existing unit test suite with `pytest` and all tests passed.
- Ran static checks/linting and there were no new issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe521379948326b6e08e237e80dfaf)