### PR TITLE
Serialize DHL foráneo address even if manual-guide checkbox is not set and clarify caption

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -4672,7 +4672,7 @@ with tab1:
         if tipo_envio == "🚚 Pedido Foráneo":
             with st.expander("📬 Dirección guía Manual  (Obligatorio al Solicitar Guia)", expanded=False):
                 solicitar_guia_manual = st.checkbox("✅ Solicitar guía manual en este pedido", key="foraneo_solicitar_guia_manual")
-                st.caption("SI NO SE ACTIVA ESTE CHECK NO SE ENVIARA LA NOTIFICACIÓN A BODEGA.")
+                st.caption("Si capturas dirección, se enviará tal como se escribió aunque no actives el check.")
                 st.markdown("**CAMPOS OBLIGATORIOS DHL (MÉXICO)**")
                 col_dhl_1, col_dhl_2 = st.columns(2)
                 with col_dhl_1:
@@ -5601,11 +5601,13 @@ with tab1:
                     st.session_state["pedido_submit_disabled"] = False
                     st.session_state.pop("pedido_submit_disabled_at", None)
                     rerun_with_pedido_loading("⏳ Recargando formulario...")
-                if (not solicitar_guia_manual) and missing_dhl_fields:
-                    st.caption("ℹ️ No se solicitó guía manual en este pedido. Los campos DHL faltantes no bloquean el registro.")
+                dhl_address_payload_to_serialize = dict(dhl_address_payload)
+                if not solicitar_guia_manual:
+                    dhl_address_payload_to_serialize["pais"] = ""
+                direccion_guia_retorno_serializada = build_dhl_mexico_address_payload(dhl_address_payload_to_serialize)
                 direccion_guia_retorno = (
-                    build_dhl_mexico_address_payload(dhl_address_payload)
-                    if solicitar_guia_manual
+                    direccion_guia_retorno_serializada
+                    if solicitar_guia_manual or direccion_guia_retorno_serializada.strip()
                     else ""
                 )
 


### PR DESCRIPTION
### Motivation
- Clarify the behavior and messaging around the DHL manual address expander so entered address data is preserved and its intent is clearer. 
- Ensure an entered DHL address for `Pedido Foráneo` can be serialized and returned with the submission even when `solicitar_guia_manual` is not checked.

### Description
- Update the expander caption text to: "Si capturas dirección, se enviará tal como se escribió aunque no actives el check.".
- Create `dhl_address_payload_to_serialize` from `dhl_address_payload` and clear the `"pais"` field when `solicitar_guia_manual` is false to avoid sending the country in that scenario.
- Build `direccion_guia_retorno_serializada` using `build_dhl_mexico_address_payload` and set `direccion_guia_retorno` to the serialized value when `solicitar_guia_manual` is true or the serialization is non-empty, instead of only when `solicitar_guia_manual` is true.
- Remove the previous informational caption that stated missing DHL fields would not block registration when manual guide was not requested.

### Testing
- Ran the existing automated test suite with `pytest` and linters with `flake8`, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe521379948326b6e08e237e80dfaf)