### PR TITLE
perf: lazy-load Tab 2 and vectorize shipping filter to reduce rerun cost

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -6742,13 +6742,16 @@ with tab2:
     if loading_message_tab2:
         message_placeholder_tab2.info(loading_message_tab2)
 
-
-    # 🔄 Cargar pedidos combinados siempre (Tab 1 y Tab 2 activos de forma permanente)
-    try:
-        df_pedidos = cargar_pedidos_combinados()
-    except Exception as e:
-        message_placeholder_tab2.error(f"❌ Error al cargar pedidos para modificación: {e}")
-        st.stop()
+    if not tab2_is_active:
+        st.caption("Pestaña en espera. Los datos se cargan al activar esta vista para reducir latencia global.")
+        df_pedidos = pd.DataFrame()
+    else:
+        # 🔄 Cargar pedidos combinados solo cuando la pestaña está activa
+        try:
+            df_pedidos = cargar_pedidos_combinados()
+        except Exception as e:
+            message_placeholder_tab2.error(f"❌ Error al cargar pedidos para modificación: {e}")
+            st.stop()
 
     # ----------------- Estado local -----------------
     selected_order_id = None
@@ -6770,11 +6773,11 @@ with tab2:
             fallback_v = df_pedidos['Vendedor'].astype(str).str.strip()
             df_pedidos.loc[df_pedidos['Vendedor_Registro'] == "", 'Vendedor_Registro'] = fallback_v
 
-        # 🔽 Filtro combinado por envío (usa Turno si es Local)
-        df_pedidos['Filtro_Envio_Combinado'] = df_pedidos.apply(
-            lambda row: row['Turno'] if (str(row.get('Tipo_Envio',"")) == "📍 Pedido Local" and pd.notna(row.get('Turno')) and str(row.get('Turno')).strip()) else row.get('Tipo_Envio', ''),
-            axis=1
-        )
+        # 🔽 Filtro combinado por envío (usa Turno si es Local) con operación vectorizada
+        tipo_envio_col = df_pedidos.get('Tipo_Envio', pd.Series('', index=df_pedidos.index)).fillna('').astype(str)
+        turno_col = df_pedidos.get('Turno', pd.Series('', index=df_pedidos.index)).fillna('').astype(str)
+        mask_local_con_turno = tipo_envio_col.eq("📍 Pedido Local") & turno_col.str.strip().ne('')
+        df_pedidos['Filtro_Envio_Combinado'] = tipo_envio_col.where(~mask_local_con_turno, turno_col)
 
         # ----------------- Controles de filtro -----------------
         col1, col2 = st.columns(2)


### PR DESCRIPTION
### Motivation
- Reduce perceived latency caused by full Streamlit reruns and expensive row-wise pandas operations when interacting with other tabs. 
- Apply a low-risk Phase 1 optimization that keeps business logic intact while avoiding unnecessary work on inactive views.

### Description
- Defer loading of Tab 2 data so `cargar_pedidos_combinados()` is only called when Tab 2 is active, and show a lightweight waiting caption otherwise. 
- Replace the row-wise `DataFrame.apply(...)` that computed `Filtro_Envio_Combinado` with a vectorized mask/`where` approach using `eq`, `str.strip` and `where` to avoid `apply(axis=1)`. 
- Preserve existing UX controls (the "🔄 Actualizar pedidos" button still clears the loader cache) and avoid changing business logic or outputs.

### Testing
- Ran `python -m py_compile app_v.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a034e672a508326905ebb0db28e6abc)