### PR TITLE
Support accented worksheet names and robustly detect inline 'CERRADA' in route closures

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -573,14 +573,19 @@ def get_local_route_closure_map(sheet_id: str) -> Dict[str, set[str]]:
         return closures
 
     configs = [
-        ("Hoja_Ruta_Manana", "☀️ Local Mañana", "LOCAL MANANA"),
-        ("Hoja_Ruta_Tarde", "🌙 Local Tarde", "LOCAL TARDE"),
-        ("Hoja_Ruta_Saltillo", "🌵 Saltillo", "SALTILLO"),
+        (["Hoja_Ruta_Mañana", "Hoja_Ruta_Manana"], "☀️ Local Mañana", "LOCAL MANANA"),
+        (["Hoja_Ruta_Tarde"], "🌙 Local Tarde", "LOCAL TARDE"),
+        (["Hoja_Ruta_Saltillo"], "🌵 Saltillo", "SALTILLO"),
     ]
-    for ws_name, shift_label, section_tag in configs:
-        try:
-            values = spreadsheet.worksheet(ws_name).get_all_values()
-        except Exception:
+    for ws_name_candidates, shift_label, section_tag in configs:
+        values = None
+        for ws_name in ws_name_candidates:
+            try:
+                values = spreadsheet.worksheet(ws_name).get_all_values()
+                break
+            except Exception:
+                continue
+        if values is None:
             continue
         last_header_date = None
         last_line_was_cerrada = False
@@ -592,12 +597,21 @@ def get_local_route_closure_map(sheet_id: str) -> Dict[str, set[str]]:
             if parsed_date:
                 last_header_date = parsed_date
             normalized_line = line.upper().replace("Á", "A").replace("É", "E").replace("Í", "I").replace("Ó", "O").replace("Ú", "U")
-            if "CERRADA" in normalized_line:
+            contains_section = section_tag in normalized_line
+            contains_cerrada = "CERRADA" in normalized_line
+
+            if contains_cerrada and contains_section and last_header_date:
+                closures.setdefault(last_header_date.isoformat(), set()).add(shift_label)
+                last_line_was_cerrada = False
+                continue
+
+            if contains_cerrada:
                 last_line_was_cerrada = True
                 continue
-            if section_tag in normalized_line and last_line_was_cerrada and last_header_date:
+
+            if contains_section and last_line_was_cerrada and last_header_date:
                 closures.setdefault(last_header_date.isoformat(), set()).add(shift_label)
-            if section_tag in normalized_line:
+            if contains_section:
                 last_line_was_cerrada = False
     return closures
 


### PR DESCRIPTION
### Motivation
- Make `get_local_route_closure_map` resilient to worksheets named with or without accents and correctly detect closures when "CERRADA" and the section tag appear on the same line.

### Description
- Update `get_local_route_closure_map` to accept multiple worksheet name candidates (e.g. `"Hoja_Ruta_Mañana"` and `"Hoja_Ruta_Manana"`) and try them in order when reading sheets.
- Refactor the worksheet-reading loop to iterate candidate names and continue if none succeed.
- Improve closure-detection logic by normalizing lines and using `contains_cerrada` and `contains_section` flags so lines that include both the section tag and `CERRADA` immediately register a closure for the last header date.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03627eaac48326944aaa6b178038fa)