### PR TITLE
Support alternative worksheet names and improve detection of closed local shifts

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -573,14 +573,19 @@ def get_local_route_closure_map(sheet_id: str) -> Dict[str, set[str]]:
         return closures
 
     configs = [
-        ("Hoja_Ruta_Manana", "☀️ Local Mañana", "LOCAL MANANA"),
-        ("Hoja_Ruta_Tarde", "🌙 Local Tarde", "LOCAL TARDE"),
-        ("Hoja_Ruta_Saltillo", "🌵 Saltillo", "SALTILLO"),
+        (["Hoja_Ruta_Mañana", "Hoja_Ruta_Manana"], "☀️ Local Mañana", "LOCAL MANANA"),
+        (["Hoja_Ruta_Tarde"], "🌙 Local Tarde", "LOCAL TARDE"),
+        (["Hoja_Ruta_Saltillo"], "🌵 Saltillo", "SALTILLO"),
     ]
-    for ws_name, shift_label, section_tag in configs:
-        try:
-            values = spreadsheet.worksheet(ws_name).get_all_values()
-        except Exception:
+    for ws_name_candidates, shift_label, section_tag in configs:
+        values = None
+        for ws_name in ws_name_candidates:
+            try:
+                values = spreadsheet.worksheet(ws_name).get_all_values()
+                break
+            except Exception:
+                continue
+        if values is None:
             continue
         last_header_date = None
         last_line_was_cerrada = False
@@ -592,12 +597,23 @@ def get_local_route_closure_map(sheet_id: str) -> Dict[str, set[str]]:
             if parsed_date:
                 last_header_date = parsed_date
             normalized_line = line.upper().replace("Á", "A").replace("É", "E").replace("Í", "I").replace("Ó", "O").replace("Ú", "U")
-            if "CERRADA" in normalized_line:
+            contains_section = section_tag in normalized_line
+            contains_cerrada = "CERRADA" in normalized_line
+
+            if contains_cerrada and last_header_date:
+                # Each worksheet maps to one shift label, so "CERRADA" under a dated header
+                # is enough to mark that shift as closed for that date.
+                closures.setdefault(last_header_date.isoformat(), set()).add(shift_label)
+                last_line_was_cerrada = False
+                continue
+
+            if contains_cerrada:
                 last_line_was_cerrada = True
                 continue
-            if section_tag in normalized_line and last_line_was_cerrada and last_header_date:
+
+            if contains_section and last_line_was_cerrada and last_header_date:
                 closures.setdefault(last_header_date.isoformat(), set()).add(shift_label)
-            if section_tag in normalized_line:
+            if contains_section:
                 last_line_was_cerrada = False
     return closures
 


### PR DESCRIPTION
### Motivation
- Allow reading route sheets that use different worksheet names (e.g. `Hoja_Ruta_Mañana` vs `Hoja_Ruta_Manana`) and make closure detection more robust when the sheet layout varies.
- Handle cases where the word `CERRADA` appears directly under a dated header or next to a section label so the correct shift is marked closed.

### Description
- `get_local_route_closure_map` now accepts a list of worksheet name candidates per configured sheet and tries each until one exists instead of assuming a single fixed name.
- The worksheet scanning loop was simplified to normalize lines once and use boolean flags `contains_section` and `contains_cerrada` to make intent clearer.
- If `contains_cerrada` and a `last_header_date` is present the code now immediately adds the corresponding `shift_label` to `closures` for that date.
- Minor variable renames and flow adjustments improve readability and ensure `last_line_was_cerrada` is reset appropriately.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03627eaac48326944aaa6b178038fa)