### PR TITLE
Support multiple worksheet name variants and improve parsing of 'CERRADA' in local route closures

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -573,14 +573,19 @@ def get_local_route_closure_map(sheet_id: str) -> Dict[str, set[str]]:
         return closures
 
     configs = [
-        ("Hoja_Ruta_Manana", "☀️ Local Mañana", "LOCAL MANANA"),
-        ("Hoja_Ruta_Tarde", "🌙 Local Tarde", "LOCAL TARDE"),
-        ("Hoja_Ruta_Saltillo", "🌵 Saltillo", "SALTILLO"),
+        (["Hoja_Ruta_Mañana", "Hoja_Ruta_Manana"], "☀️ Local Mañana", "LOCAL MANANA"),
+        (["Hoja_Ruta_Tarde"], "🌙 Local Tarde", "LOCAL TARDE"),
+        (["Hoja_Ruta_Saltillo"], "🌵 Saltillo", "SALTILLO"),
     ]
-    for ws_name, shift_label, section_tag in configs:
-        try:
-            values = spreadsheet.worksheet(ws_name).get_all_values()
-        except Exception:
+    for ws_name_candidates, shift_label, section_tag in configs:
+        values = None
+        for ws_name in ws_name_candidates:
+            try:
+                values = spreadsheet.worksheet(ws_name).get_all_values()
+                break
+            except Exception:
+                continue
+        if values is None:
             continue
         last_header_date = None
         last_line_was_cerrada = False
@@ -591,13 +596,24 @@ def get_local_route_closure_map(sheet_id: str) -> Dict[str, set[str]]:
             parsed_date = parse_route_header_date(line)
             if parsed_date:
                 last_header_date = parsed_date
-            normalized_line = line.upper().replace("Á", "A").replace("É", "E").replace("Í", "I").replace("Ó", "O").replace("Ú", "U")
-            if "CERRADA" in normalized_line:
+            normalized_line = line.upper().replace("Á", "A").replace("É", "E").replace("Í", "I").replace("Ó", "O").replace("Ú", "U").replace("Ñ", "N")
+            contains_section = section_tag in normalized_line
+            contains_cerrada = "CERRADA" in normalized_line
+
+            if contains_cerrada and last_header_date:
+                # Each worksheet maps to one shift label, so "CERRADA" under a dated header
+                # is enough to mark that shift as closed for that date.
+                closures.setdefault(last_header_date.isoformat(), set()).add(shift_label)
+                last_line_was_cerrada = False
+                continue
+
+            if contains_cerrada:
                 last_line_was_cerrada = True
                 continue
-            if section_tag in normalized_line and last_line_was_cerrada and last_header_date:
+
+            if contains_section and last_line_was_cerrada and last_header_date:
                 closures.setdefault(last_header_date.isoformat(), set()).add(shift_label)
-            if section_tag in normalized_line:
+            if contains_section:
                 last_line_was_cerrada = False
     return closures
 


### PR DESCRIPTION
### Motivation
- Worksheets may use accented or alternate names and closure markers can appear either on the same line as a date header or on the following section line, so parsing must be more robust.

### Description
- Accept lists of worksheet name candidates in `get_local_route_closure_map` and try each candidate until a worksheet is found.
- Normalize lines to collapse accented characters including `Ñ` and compute `contains_section` and `contains_cerrada` flags for clearer logic.
- When `CERRADA` is present under a dated header, immediately record the closure for that shift label; preserve the previous behavior where `CERRADA` on its own line affects the following section line via `last_line_was_cerrada`.
- Refactor iteration variable names and control flow in `get_local_route_closure_map` for readability and reliability.

### Testing
- Ran the project's automated test suite focusing on `parse_route_header_date` and `get_local_route_closure_map`, and the relevant tests passed.
- Ran static checks/linting and no issues were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03627eaac48326944aaa6b178038fa)