### PR TITLE
Fix AccessDenied for Data Especiales attachment links by regenerating S3 signed URLs

### DIFF
--- a/app_admin.py
+++ b/app_admin.py
@@ -2055,6 +2055,7 @@ def get_s3_file_download_url(
     expires_in=3600,
     *,
     prefer_inline_view: bool = False,
+    force_presigned: bool = False,
 ): # Acepta s3_client_instance
     clean_key = extract_s3_key(object_key_or_url)
     if not clean_key:
@@ -2066,7 +2067,7 @@ def get_s3_file_download_url(
 
     clean_key_lower = clean_key.lower()
 
-    use_permanent_url = S3_USE_PERMANENT_URLS and S3_PUBLIC_BASE_URL
+    use_permanent_url = (S3_USE_PERMANENT_URLS and S3_PUBLIC_BASE_URL) and not force_presigned
     if prefer_inline_view and clean_key_lower.endswith(INLINE_EXT):
         use_permanent_url = False
 
@@ -6263,7 +6264,11 @@ with tab4:
         resolved_urls = []
         for url in _normalize_urls(value):
             if is_s3_url(url):
-                resolved_urls.append(get_s3_file_download_url(s3_client, url, prefer_inline_view=True))
+                resolved_urls.append(
+                    get_s3_file_download_url(
+                        s3_client, url, prefer_inline_view=True, force_presigned=True
+                    )
+                )
             else:
                 resolved_urls.append(url)
         return resolved_urls

--- a/app_admin.py
+++ b/app_admin.py
@@ -6258,8 +6258,20 @@ with tab4:
         if c not in df_ce.columns:
             df_ce[c] = ""
 
+    def _resolve_urls_for_output(value) -> list[str]:
+        """Resuelve URLs de adjuntos para vista/Excel (regenera firma S3 cuando aplica)."""
+        resolved_urls = []
+        for url in _normalize_urls(value):
+            if is_s3_url(url):
+                resolved_urls.append(get_s3_file_download_url(s3_client, url, prefer_inline_view=True))
+            else:
+                resolved_urls.append(url)
+        return resolved_urls
+
     # Links listos para tabla/Excel
-    df_ce["Links_Adjuntos"] = df_ce["Adjuntos"].apply(lambda v: "\n".join(_normalize_urls(v)) if str(v).strip() else "")
+    df_ce["Links_Adjuntos"] = df_ce["Adjuntos"].apply(
+        lambda v: "\n".join(_resolve_urls_for_output(v)) if str(v).strip() else ""
+    )
     df_ce["Link_Guia"] = df_ce["Hoja_Ruta_Mensajero"].astype(str).fillna("")
     # prioriza dictamen garantía; si no, nota crédito
     df_ce["Link_Dictamen_o_Nota"] = df_ce.apply(


### PR DESCRIPTION
### Motivation
- Exported `Links_Adjuntos` in the "🗂️ Data Especiales" sheet sometimes contained raw or expired S3 URLs which caused intermittent `AccessDenied` errors when opening attachments from the Excel export.

### Description
- Added `_resolve_urls_for_output` and changed the `Links_Adjuntos` construction to regenerate signed S3 download URLs with `get_s3_file_download_url(s3_client, ..., prefer_inline_view=True)` for S3 links while leaving non‑S3 links unchanged.

### Testing
- Ran `python -m py_compile app_admin.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04f5ab702c832699b483cc883963a9)