### PR TITLE
Align Data Especiales attachment links with permanent URL behavior

### DIFF
--- a/app_admin.py
+++ b/app_admin.py
@@ -6258,8 +6258,29 @@ with tab4:
         if c not in df_ce.columns:
             df_ce[c] = ""
 
+    def _resolve_urls_for_output(value) -> list[str]:
+        urls = _normalize_urls(value)
+        if not urls:
+            return []
+
+        resolved = []
+        for url in urls:
+            if s3_client and is_s3_url(url):
+                resolved.append(
+                    get_s3_file_download_url(
+                        s3_client,
+                        url,
+                        prefer_inline_view=True,
+                    )
+                )
+            else:
+                resolved.append(url)
+        return resolved
+
     # Links listos para tabla/Excel
-    df_ce["Links_Adjuntos"] = df_ce["Adjuntos"].apply(lambda v: "\n".join(_normalize_urls(v)) if str(v).strip() else "")
+    df_ce["Links_Adjuntos"] = df_ce["Adjuntos"].apply(
+        lambda v: "\n".join(_resolve_urls_for_output(v)) if str(v).strip() else ""
+    )
     df_ce["Link_Guia"] = df_ce["Hoja_Ruta_Mensajero"].astype(str).fillna("")
     # prioriza dictamen garantía; si no, nota crédito
     df_ce["Link_Dictamen_o_Nota"] = df_ce.apply(


### PR DESCRIPTION
### Motivation
- En la vista “🗂️ Data Especiales” los enlaces en `Links_Adjuntos` se estaban dejando como URLs normalizadas que podían resolverse como presigned con expiración, lo que rompía la paridad con el flujo de Confirmados.
- El objetivo es que cuando exista la configuración global de URLs permanentes (`S3_USE_PERMANENT_URLS` + `S3_PUBLIC_BASE_URL`) los adjuntos usen esas URLs permanentes y que solo se generen presigned cuando el flujo estándar lo determine.

### Description
- Añadí la función local `_resolve_urls_for_output(value)` que normaliza y por cada URL S3 llama a `get_s3_file_download_url(s3_client, url, prefer_inline_view=True)` para resolver la URL usando el flujo estándar. 
- Reemplacé la asignación de `df_ce["Links_Adjuntos"]` para que use `_resolve_urls_for_output(...)` y junte las URLs resultantes con saltos de línea. 
- No se añadió `force_presigned=True` en la nueva llamada y se preserva `prefer_inline_view=True`, manteniendo la posibilidad de generar URLs permanentes cuando `S3_USE_PERMANENT_URLS` y `S3_PUBLIC_BASE_URL` están activas. 
- No se detectó ni cambió ninguna configuración temporal como `S3_EXCEL_LINK_EXPIRES_IN` durante el cambio. 

### Testing
- Ejecuté `python -m py_compile app_admin.py` y la compilación estática del archivo completó con éxito.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04ff2cdc508326903d0c01b64479ae)