### PR TITLE
Mejora indicador visual de vista MTY/CDMX en Nuevo Pedido

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -3920,7 +3920,6 @@ with tab1:
     tab1_is_active = default_tab == TAB_INDEX_TAB1
     if tab1_is_active:
         st.session_state["current_tab_index"] = TAB_INDEX_TAB1
-    st.header("📝 Nuevo Pedido")
     if st.session_state.pop("tab1_draft_was_restored", False):
         st.info(
             "🧩 Se recuperó automáticamente un borrador local de tu captura. "
@@ -3938,15 +3937,26 @@ with tab1:
             current_view_mode = "mty"
             st.session_state[tab1_view_mode_key] = current_view_mode
         st.caption("Vista de captura para vendedores:")
+        st.markdown(
+            f"**Vista activa:** {'🔴 CDMX' if current_view_mode == 'cdmx' else '🔴 MTY'}"
+        )
         col_view_mty, col_view_cdmx = st.columns(2)
         with col_view_mty:
-            if st.button("Vista vendedores MTY", use_container_width=True):
+            if st.button(
+                "🔴 Vista vendedores MTY" if current_view_mode == "mty" else "Vista vendedores MTY",
+                type="primary" if current_view_mode == "mty" else "secondary",
+                use_container_width=True,
+            ):
                 if st.session_state.get(tab1_view_mode_key) != "mty":
                     st.session_state[tab1_view_mode_key] = "mty"
                     pass  # Evita recarga inmediata; los cambios se aplican al enviar el formulario
                 current_view_mode = "mty"
         with col_view_cdmx:
-            if st.button("Vista vendedores CDMX", use_container_width=True):
+            if st.button(
+                "🔴 Vista vendedores CDMX" if current_view_mode == "cdmx" else "Vista vendedores CDMX",
+                type="primary" if current_view_mode == "cdmx" else "secondary",
+                use_container_width=True,
+            ):
                 if st.session_state.get(tab1_view_mode_key) != "cdmx":
                     st.session_state[tab1_view_mode_key] = "cdmx"
                     pass  # Evita recarga inmediata; los cambios se aplican al enviar el formulario
@@ -3954,6 +3964,14 @@ with tab1:
     else:
         st.session_state.pop(tab1_view_mode_key, None)
         current_view_mode = "mty"
+
+    if tab1_can_toggle_view_mode:
+        if current_view_mode == "cdmx":
+            st.header("🏙️ Nuevo Pedido CDMX")
+        else:
+            st.header("🏔️ Nuevo Pedido MTY")
+    else:
+        st.header("📝 Nuevo Pedido")
 
     tab1_special_shipping = current_view_mode == "cdmx"
     tab1_emulate_cdmx_vendor_view = (


### PR DESCRIPTION
### Motivation
- Hacer más evidente para el vendedor en qué vista está (MTY o CDMX) mediante indicadores visuales y títulos claros.
- Diferenciar los botones de cambio de vista para que el estado seleccionado sea inmediato y más accesible.

### Description
- Se modificó `app_v.py` para reemplazar el encabezado fijo `📝 Nuevo Pedido` por un título dinámico que muestra `🏔️ Nuevo Pedido MTY` o `🏙️ Nuevo Pedido CDMX` cuando el usuario puede alternar vista, y mantiene `📝 Nuevo Pedido` para usuarios sin alternancia.
- Se añadió una línea de estado con `st.markdown` que muestra la vista activa como `**Vista activa:** 🔴 MTY` o `🔴 CDMX` según `current_view_mode`.
- Los botones de cambio de vista ahora muestran el prefijo `🔴` cuando están activos y usan propiedades de estilo (`type="primary"` / `type="secondary"`) para resaltarse visualmente, y siguen escribiendo la clave de modo en `tab1_view_mode_key`.
- El cambio se aplica únicamente en la sección de registro de pedidos (tab1) y conserva la lógica previa de modo y etiquetas de envío.

### Testing
- Se ejecutó la comprobación sintáctica con `python -m py_compile app_v.py` y finalizó correctamente.
- No se ejecutaron pruebas unitarias automáticas adicionales en este cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e01a16d0483268269705dbe12e648)