### PR TITLE
Disable automatic URL preview expanders in `render_attachment_link`

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -3518,7 +3518,7 @@ def add_url_preview_expander(url: str, display_label: str) -> None:
 
 
 def render_attachment_link(url: str, label: str | None = None, icon: str | None = None, bullet: bool = True) -> None:
-    """Render a file link and automatically include an expandable preview."""
+    """Render a file link without generating inline preview expanders."""
     if not __has(url):
         return
 
@@ -3537,10 +3537,6 @@ def render_attachment_link(url: str, label: str | None = None, icon: str | None 
             st.markdown(f"{prefix}[{display_label}]({sanitized or url})")
         else:
             st.markdown(f"{prefix}{__s(url)}")
-
-    if __is_url(url):
-        add_url_preview_expander(url, display_label)
-
 
 def render_uploaded_file_preview(file_obj) -> None:
     """Show a preview expander for an uploaded Streamlit file."""


### PR DESCRIPTION
### Motivation

- Prevent automatic creation of inline preview expanders for URL attachments to avoid unexpected network requests and duplicate previews.

### Description

- Updated the `render_attachment_link` docstring to indicate it no longer generates inline preview expanders.
- Removed the automatic call to `add_url_preview_expander` so URL attachments are rendered as plain links only. 
- Left existing uploaded-file preview behavior intact via `render_uploaded_file_preview` and the separate `add_url_preview_expander` helper.

### Testing

- Ran the test suite with `pytest -q` and all tests passed. 
- Ran `flake8` for linting and no new issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e0246b9348326be6beeaaeba4293c)