### PR TITLE
Add explicit Tab1 view-mode UI, active state indicators, and immediate rerun on change

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -3920,7 +3920,6 @@ with tab1:
     tab1_is_active = default_tab == TAB_INDEX_TAB1
     if tab1_is_active:
         st.session_state["current_tab_index"] = TAB_INDEX_TAB1
-    st.header("📝 Nuevo Pedido")
     if st.session_state.pop("tab1_draft_was_restored", False):
         st.info(
             "🧩 Se recuperó automáticamente un borrador local de tu captura. "
@@ -3938,22 +3937,41 @@ with tab1:
             current_view_mode = "mty"
             st.session_state[tab1_view_mode_key] = current_view_mode
         st.caption("Vista de captura para vendedores:")
+        st.markdown(
+            f"**Vista activa:** {'🔴 CDMX' if current_view_mode == 'cdmx' else '🔴 MTY'}"
+        )
         col_view_mty, col_view_cdmx = st.columns(2)
         with col_view_mty:
-            if st.button("Vista vendedores MTY", use_container_width=True):
+            if st.button(
+                "🔴 Vista vendedores MTY" if current_view_mode == "mty" else "Vista vendedores MTY",
+                type="primary" if current_view_mode == "mty" else "secondary",
+                use_container_width=True,
+            ):
                 if st.session_state.get(tab1_view_mode_key) != "mty":
                     st.session_state[tab1_view_mode_key] = "mty"
-                    pass  # Evita recarga inmediata; los cambios se aplican al enviar el formulario
+                    st.rerun()
                 current_view_mode = "mty"
         with col_view_cdmx:
-            if st.button("Vista vendedores CDMX", use_container_width=True):
+            if st.button(
+                "🔴 Vista vendedores CDMX" if current_view_mode == "cdmx" else "Vista vendedores CDMX",
+                type="primary" if current_view_mode == "cdmx" else "secondary",
+                use_container_width=True,
+            ):
                 if st.session_state.get(tab1_view_mode_key) != "cdmx":
                     st.session_state[tab1_view_mode_key] = "cdmx"
-                    pass  # Evita recarga inmediata; los cambios se aplican al enviar el formulario
+                    st.rerun()
                 current_view_mode = "cdmx"
     else:
         st.session_state.pop(tab1_view_mode_key, None)
         current_view_mode = "mty"
+
+    if tab1_can_toggle_view_mode:
+        if current_view_mode == "cdmx":
+            st.header("🏙️ Nuevo Pedido CDMX")
+        else:
+            st.header("🏔️ Nuevo Pedido MTY")
+    else:
+        st.header("📝 Nuevo Pedido")
 
     tab1_special_shipping = current_view_mode == "cdmx"
     tab1_emulate_cdmx_vendor_view = (


### PR DESCRIPTION
### Motivation
- Improve the user experience for Tab1 by making the active vendor view mode explicit and by applying view-mode changes immediately. 
- Make the MTY/CDMX toggle clearer so users know which capture layout is active. 

### Description
- Replaced the unconditional `st.header("📝 Nuevo Pedido")` with conditional headers that show `"🏙️ Nuevo Pedido CDMX"` or `"🏔️ Nuevo Pedido MTY"` when view toggling is available, otherwise defaulting to `"📝 Nuevo Pedido"`.
- Added an active-view indicator via `st.markdown` that shows `🔴 CDMX` or `🔴 MTY` based on the current `tab1_view_mode_key` value.
- Updated the MTY/CDMX toggle buttons to include the active indicator in the label and set button `type` to `primary` for the active mode and `secondary` for the inactive mode, and kept `use_container_width=True` for consistency.
- Replaced the previous no-op `pass` behavior after changing the view mode with `st.rerun()` to force an immediate UI refresh when the mode changes.

### Testing
- Ran the repository automated test suite with `pytest` and the tests completed successfully. 
- Verified the UI changes by interacting with the MTY/CDMX toggle in a local Streamlit run and confirmed the header, active indicator, button styles, and immediate rerun behavior worked as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e01a16d0483268269705dbe12e648)