### PR TITLE
Ventas/reportes: cargar sólo turnos CDMX/Aula desde hoja histórica y simplificar lógica

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -2797,23 +2797,27 @@ def cargar_pedidos():
 
 @st.cache_data(ttl=300)
 def cargar_pedidos_ventas_reportes():
-    """Carga pedidos de data_pedidos + datos_pedidos para la vista de reportes."""
+    """Carga pedidos de datos_pedidos filtrando solo turnos CDMX/Aula para la vista de reportes."""
     spreadsheet = g_spread_client.open_by_key("1aWkSelodaz0nWfQx7FZAysGnIYGQFJxAN7RO3YgCiZY")
-    frames: list[pd.DataFrame] = []
-    for nombre_hoja in (SHEET_PEDIDOS_OPERATIVOS, SHEET_PEDIDOS_HISTORICOS):
-        try:
-            sheet = spreadsheet.worksheet(nombre_hoja)
-            frame = pd.DataFrame(sheet.get_all_records())
-            if not frame.empty:
-                frame["Fuente"] = nombre_hoja
-            frames.append(frame)
-        except Exception:
-            continue
 
-    if not frames:
+    try:
+        sheet = spreadsheet.worksheet(SHEET_PEDIDOS_HISTORICOS)
+    except Exception:
         return pd.DataFrame()
 
-    return pd.concat(frames, ignore_index=True, sort=False)
+    frame = pd.DataFrame(sheet.get_all_records())
+    if frame.empty:
+        return frame
+
+    if "Turno" not in frame.columns:
+        return pd.DataFrame()
+
+    turnos_validos = {"🌆 Local CDMX", "🎓 Recoge en Aula"}
+    frame["Turno_norm"] = frame["Turno"].astype(str).str.strip()
+    frame = frame[frame["Turno_norm"].isin(turnos_validos)].copy()
+    frame.drop(columns=["Turno_norm"], inplace=True)
+    frame["Fuente"] = SHEET_PEDIDOS_HISTORICOS
+    return frame
 
 
 usuario_activo = ensure_user_logged_in()
@@ -6434,7 +6438,6 @@ if tab_ventas_reportes is not None:
             st.session_state["current_tab_index"] = TAB_INDEX_REPORTES
 
         st.header("📊 Ventas y Reportes")
-        st.caption("Pedidos registrados por CARITO82 y KAREN58.")
 
         try:
             df_ventas = cargar_pedidos_ventas_reportes()
@@ -6445,11 +6448,6 @@ if tab_ventas_reportes is not None:
         if df_ventas.empty:
             st.info("No hay pedidos para mostrar.")
         else:
-            if "id_vendedor" not in df_ventas.columns:
-                df_ventas["id_vendedor"] = ""
-
-            df_ventas["id_vendedor_norm"] = df_ventas["id_vendedor"].apply(normalize_vendedor_id)
-            df_ventas = df_ventas[df_ventas["id_vendedor_norm"].isin(LOCAL_TURNO_COMBINADO_IDS)].copy()
 
             columnas_reporte = [
                 "Folio_Factura",


### PR DESCRIPTION
### Motivation
- Limitar la vista de `Ventas y Reportes` a los pedidos relevantes para los turnos locales (CDMX/Aula) y simplificar la fuente de datos para evitar mezclas innecesarias entre hojas.
- Evitar errores por falta de columna o por falta de la hoja histórica cuando se construyen los reportes.

### Description
- Reescribe `cargar_pedidos_ventas_reportes` para leer únicamente `SHEET_PEDIDOS_HISTORICOS`, devolver un `DataFrame` vacío si la hoja o la columna `Turno` no existen, y añadir la columna `Fuente` con el nombre de la hoja cuando hay datos.
- Normaliza `Turno` a `Turno_norm` y filtra solo los valores `"🌆 Local CDMX"` y `"🎓 Recoge en Aula"`, eliminando la columna temporal y devolviendo el `DataFrame` filtrado.
- Elimina la antigua lógica que concatenaba `SHEET_PEDIDOS_OPERATIVOS` y `SHEET_PEDIDOS_HISTORICOS` y la subsecuente filtración por `id_vendedor` en la vista de reportes; también se removió la `caption` del bloque de UI correspondiente.

### Testing
- No se ejecutaron pruebas automatizadas contra estos cambios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e047ef67083269a864fa63598fc54)