### PR TITLE
Limit Ventas y Reportes to CDMX/Aula turnos and simplify data source

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -2797,23 +2797,36 @@ def cargar_pedidos():
 
 @st.cache_data(ttl=300)
 def cargar_pedidos_ventas_reportes():
-    """Carga pedidos de data_pedidos + datos_pedidos para la vista de reportes."""
+    """Carga pedidos de datos_pedidos filtrando solo turnos CDMX/Aula para la vista de reportes."""
     spreadsheet = g_spread_client.open_by_key("1aWkSelodaz0nWfQx7FZAysGnIYGQFJxAN7RO3YgCiZY")
-    frames: list[pd.DataFrame] = []
-    for nombre_hoja in (SHEET_PEDIDOS_OPERATIVOS, SHEET_PEDIDOS_HISTORICOS):
-        try:
-            sheet = spreadsheet.worksheet(nombre_hoja)
-            frame = pd.DataFrame(sheet.get_all_records())
-            if not frame.empty:
-                frame["Fuente"] = nombre_hoja
-            frames.append(frame)
-        except Exception:
-            continue
 
-    if not frames:
+    try:
+        sheet = spreadsheet.worksheet(SHEET_PEDIDOS_HISTORICOS)
+    except Exception:
         return pd.DataFrame()
 
-    return pd.concat(frames, ignore_index=True, sort=False)
+    frame = pd.DataFrame(sheet.get_all_records())
+    if frame.empty:
+        return frame
+
+    if "Turno" not in frame.columns:
+        return pd.DataFrame()
+
+    turnos_validos_norm = {
+        normalizar("🌆 Local CDMX").strip().lower(),
+        normalizar("🎓 Recoge en Aula").strip().lower(),
+    }
+    frame["Turno_norm"] = (
+        frame["Turno"]
+        .astype(str)
+        .apply(normalizar)
+        .str.strip()
+        .str.lower()
+    )
+    frame = frame[frame["Turno_norm"].isin(turnos_validos_norm)].copy()
+    frame.drop(columns=["Turno_norm"], inplace=True)
+    frame["Fuente"] = SHEET_PEDIDOS_HISTORICOS
+    return frame
 
 
 usuario_activo = ensure_user_logged_in()
@@ -6434,7 +6447,6 @@ if tab_ventas_reportes is not None:
             st.session_state["current_tab_index"] = TAB_INDEX_REPORTES
 
         st.header("📊 Ventas y Reportes")
-        st.caption("Pedidos registrados por CARITO82 y KAREN58.")
 
         try:
             df_ventas = cargar_pedidos_ventas_reportes()
@@ -6445,11 +6457,6 @@ if tab_ventas_reportes is not None:
         if df_ventas.empty:
             st.info("No hay pedidos para mostrar.")
         else:
-            if "id_vendedor" not in df_ventas.columns:
-                df_ventas["id_vendedor"] = ""
-
-            df_ventas["id_vendedor_norm"] = df_ventas["id_vendedor"].apply(normalize_vendedor_id)
-            df_ventas = df_ventas[df_ventas["id_vendedor_norm"].isin(LOCAL_TURNO_COMBINADO_IDS)].copy()
 
             columnas_reporte = [
                 "Folio_Factura",


### PR DESCRIPTION
### Motivation
- Restrict the sales/report view to only relevant turnos (Local CDMX and Recoge en Aula) to avoid showing unrelated orders.
- Simplify and harden data loading by using a single authoritative sheet and handling missing/invalid data gracefully.
- Remove vendor-based filtering to rely on explicit turno filtering for which rows should appear in reports.

### Description
- Updated `cargar_pedidos_ventas_reportes` to open only `SHEET_PEDIDOS_HISTORICOS`, return an empty `DataFrame` if the sheet is unavailable, and stop concatenating multiple sheets.
- Added normalization of the `Turno` column and filter to keep only normalized values for `"🌆 Local CDMX"` and `"🎓 Recoge en Aula"`, then set `Fuente` to `SHEET_PEDIDOS_HISTORICOS` before returning the frame.
- Removed the previous vendor-id normalization and filtering logic in the `Ventas y Reportes` tab, and removed the caption referencing specific users.
- Adjusted the function docstring to reflect the new behavior and added defensive checks for missing `Turno` column and empty frames.

### Testing
- No automated tests were added or modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e047ef67083269a864fa63598fc54)