### PR TITLE
Agregar checkbox para enviar devolución sin refacturar a bodega como modificación

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -8644,6 +8644,11 @@ with tab4:
                                 accept_multiple_files=True,
                                 key=f"{row_key}_comprobantes_extra",
                             )
+                            enviar_aviso_bodega_modificacion = st.checkbox(
+                                "📦 Enviar aviso a bodega como modificación",
+                                key=f"{row_key}_enviar_aviso_bodega_modificacion",
+                                help="Si se marca, el caso cambia a ✏️ Modificación y se limpia Completados_Limpiado.",
+                            )
                             submit_folio_nuevo = st.form_submit_button("Guardar Folio Nuevo")
 
                         if submit_folio_nuevo:
@@ -8682,6 +8687,18 @@ with tab4:
                                             "range": rowcol_to_a1(row_idx, col_idx("Modificacion_Surtido")),
                                             "values": [[str(notas_devolucion).strip()]],
                                         })
+
+                                    if enviar_aviso_bodega_modificacion:
+                                        if col_exists("Seguimiento"):
+                                            cell_updates.append({
+                                                "range": rowcol_to_a1(row_idx, col_idx("Seguimiento")),
+                                                "values": [["✏️ Modificación"]],
+                                            })
+                                        if col_exists("Completados_Limpiado"):
+                                            cell_updates.append({
+                                                "range": rowcol_to_a1(row_idx, col_idx("Completados_Limpiado")),
+                                                "values": [[""]],
+                                            })
 
                                     direccion_guia_retorno_normalizada = str(direccion_guia_retorno_pendiente or "").strip()
                                     if col_exists("Direccion_Guia_Retorno"):


### PR DESCRIPTION
### Motivation
- Facilitar que desde la UI de `app_v.py` se pueda optar por notificar a bodega que una devolución sin refacturar se trate como una modificación al guardar el Folio Nuevo.

### Description
- Se añadió un checkbox `📦 Enviar aviso a bodega como modificación` (clave `{row_key}_enviar_aviso_bodega_modificacion`) en el formulario de `Casos Especiales > Devoluciones sin refacturar — Captura el Folio Nuevo` en `app_v.py`.
- Cuando el checkbox está marcado al guardar, se agrega una actualización para fijar `Seguimiento` a `✏️ Modificación` y para limpiar `Completados_Limpiado` en la fila correspondiente de la hoja de casos especiales.
- Se preservó la lógica existente de guardado de `Folio_Factura` (con prefijo `*`), `Modificacion_Surtido`, dirección, adjuntos y comprobantes, únicamente agregando las actualizaciones condicionales controladas por el checkbox.

### Testing
- Se ejecutó `python -m py_compile app_v.py` y la compilación sintáctica fue exitosa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e254cfac48326980ac2e93d5aead7)