### PR TITLE
Fix false local shift closures when parsing CERRADA rows

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -600,15 +600,14 @@ def get_local_route_closure_map(sheet_id: str) -> Dict[str, set[str]]:
             contains_section = section_tag in normalized_line
             contains_cerrada = "CERRADA" in normalized_line
 
-            if contains_cerrada and last_header_date:
-                # Each worksheet maps to one shift label, so "CERRADA" under a dated header
-                # is enough to mark that shift as closed for that date.
-                closures.setdefault(last_header_date.isoformat(), set()).add(shift_label)
-                last_line_was_cerrada = False
-                continue
-
             if contains_cerrada:
-                last_line_was_cerrada = True
+                # Mark closure only when CERRADA belongs to this section (same line) or
+                # appears immediately above the section label.
+                if contains_section and last_header_date:
+                    closures.setdefault(last_header_date.isoformat(), set()).add(shift_label)
+                    last_line_was_cerrada = False
+                else:
+                    last_line_was_cerrada = True
                 continue
 
             if contains_section and last_line_was_cerrada and last_header_date:


### PR DESCRIPTION
### Motivation
- Evitar falsos positivos en la detección de turnos cerrados cuando la palabra `CERRADA` aparece en líneas que no corresponden a la sección del turno. 
- Mejorar la precisión del aviso mostrado en la UI de turnos locales (por ejemplo, que no aparezca `🌙 Local Tarde` cerrada si solo lo está la mañana). 

### Description
- Ajusté la función `get_local_route_closure_map` para cambiar el tratamiento de líneas que contienen `CERRADA` y distinguir si pertenecen a la misma línea de la sección (`contains_section`) o si aparecen inmediatamente antes de ella. 
- Ahora se marca una clausura solo si `contains_cerrada` aparece en la misma línea que la sección y hay `last_header_date`, o si `contains_cerrada` aparece en la línea anterior a la sección (usando la bandera `last_line_was_cerrada`). 
- Eliminé la lógica previa que marcaba automáticamente la clausura cuando `CERRADA` aparecía bajo un header sin verificar relación con la sección. 

### Testing
- Ejecuté `python -m py_compile app_v.py` y la compilación de sintaxis del módulo fue exitosa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e3a23167c8326943bb86635281f09)