### PR TITLE
Handle column C and 'CERRADA' header cases in get_local_route_closure_map

### DIFF
--- a/app_v.py
+++ b/app_v.py
@@ -587,34 +587,45 @@ def get_local_route_closure_map(sheet_id: str) -> Dict[str, set[str]]:
                 continue
         if values is None:
             continue
-        last_header_date = None
-        last_line_was_cerrada = False
+
+        pending_cerrada = False
         for row in values:
-            line = " ".join(str(cell or "").strip() for cell in row if str(cell or "").strip())
-            if not line:
+            # El reporte operativo usa la columna C para estados/encabezados de turno.
+            # Leemos primero esa columna para evitar falsos positivos en otras columnas.
+            col_c = str(row[2] if len(row) > 2 else "" or "").strip()
+            if not col_c:
                 continue
-            parsed_date = parse_route_header_date(line)
-            if parsed_date:
-                last_header_date = parsed_date
-            normalized_line = line.upper().replace("Á", "A").replace("É", "E").replace("Í", "I").replace("Ó", "O").replace("Ú", "U").replace("Ñ", "N")
-            contains_section = section_tag in normalized_line
+
+            normalized_line = (
+                col_c.upper()
+                .replace("Á", "A")
+                .replace("É", "E")
+                .replace("Í", "I")
+                .replace("Ó", "O")
+                .replace("Ú", "U")
+                .replace("Ñ", "N")
+            )
             contains_cerrada = "CERRADA" in normalized_line
+            parsed_date = parse_route_header_date(col_c)
+            contains_section = section_tag in normalized_line
 
-            if contains_cerrada and last_header_date:
-                # Each worksheet maps to one shift label, so "CERRADA" under a dated header
-                # is enough to mark that shift as closed for that date.
-                closures.setdefault(last_header_date.isoformat(), set()).add(shift_label)
-                last_line_was_cerrada = False
+            # Casos soportados en columna C:
+            # 1) "CERRADA" en fila previa, y después encabezado+turno.
+            # 2) Encabezado+turno y "CERRADA" en la misma celda (con saltos de línea).
+            if contains_cerrada and not parsed_date and not contains_section:
+                pending_cerrada = True
                 continue
 
-            if contains_cerrada:
-                last_line_was_cerrada = True
+            if parsed_date and contains_section:
+                if contains_cerrada or pending_cerrada:
+                    closures.setdefault(parsed_date.isoformat(), set()).add(shift_label)
+                pending_cerrada = False
                 continue
 
-            if contains_section and last_line_was_cerrada and last_header_date:
-                closures.setdefault(last_header_date.isoformat(), set()).add(shift_label)
-            if contains_section:
-                last_line_was_cerrada = False
+            # Si aparece un nuevo encabezado/turno sin CERRADA, limpiamos pendiente.
+            if parsed_date or contains_section:
+                pending_cerrada = False
+
     return closures
 
 


### PR DESCRIPTION
### Motivation
- Improve detection of closed local shifts in route spreadsheets by avoiding false positives from other columns and handling cases where "CERRADA" appears before or inside the header cell.
- Ensure the parser reads the operational report structure where status and headers are provided in column C.
- Make closure detection robust to accented characters and common variations of the section label.

### Description
- Update `get_local_route_closure_map` to read and normalize only column C (`col_c`) for status and header detection instead of concatenating the whole row.
- Add a `pending_cerrada` flag to track a `CERRADA` value on a previous row and apply it to the next parsed header date when appropriate.
- Parse header dates from column C with `parse_route_header_date` and mark closures for the corresponding `shift_label` when either the same cell contains `CERRADA` or a prior row had `CERRADA`.
- Normalize accented characters and section tags before matching and clear the `pending_cerrada` state when a new header/section without closure appears.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e3a23167c8326943bb86635281f09)